### PR TITLE
feat: implement scheduler-core SM-2 engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,14 +62,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "card-store"
 version = "0.1.0"
+
+[[package]]
+name = "cc"
+version = "1.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -82,6 +113,19 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -131,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +201,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "fnv"
@@ -183,6 +239,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,10 +307,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -272,6 +383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +397,12 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "scheduler-core"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "maplit",
+ "thiserror",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -334,6 +457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +490,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -417,6 +566,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,10 +595,122 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/scheduler-core/Cargo.toml
+++ b/crates/scheduler-core/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
-name = "scheduler-core"
-version = "0.1.0"
-edition = "2024"
+edition="2024"
+name   ="scheduler-core"
+version="0.1.0"
 
 [dependencies]
+chrono   ="0.4"
+thiserror="1"
+uuid     ={ version="1", features=["v4"] }
+
+[dev-dependencies]
+maplit="1"

--- a/crates/scheduler-core/src/lib.rs
+++ b/crates/scheduler-core/src/lib.rs
@@ -1,0 +1,406 @@
+//! Scheduler core library implementing SM-2 scheduling and unlock policy.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{Duration, NaiveDate};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Configuration for the scheduler.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchedulerConfig {
+    /// Initial ease factor assigned to brand new cards.
+    pub initial_ease_factor: f32,
+    /// Minimum ease factor allowed.
+    pub ease_minimum: f32,
+    /// Maximum ease factor allowed.
+    pub ease_maximum: f32,
+    /// Learning steps in minutes for new cards.
+    pub learning_steps_minutes: Vec<u32>,
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            initial_ease_factor: 2.5,
+            ease_minimum: 1.3,
+            ease_maximum: 2.8,
+            learning_steps_minutes: vec![1, 10],
+        }
+    }
+}
+
+/// Possible grades assigned to a review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewGrade {
+    /// Repeat immediately.
+    Again,
+    /// Hard recall.
+    Hard,
+    /// Satisfactory recall.
+    Good,
+    /// Effortless recall.
+    Easy,
+}
+
+/// Card state classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardState {
+    /// Never seen.
+    New,
+    /// Currently in the learning queue.
+    Learning,
+    /// Graduated and scheduled via spaced repetition.
+    Review,
+    /// Relearning after a lapse.
+    Relearning,
+}
+
+/// Different card kinds supported by the scheduler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CardKind {
+    /// Opening move referencing the shared parent prefix.
+    Opening { parent_prefix: String },
+    /// Tactic puzzle independent of the unlock policy.
+    Tactic,
+}
+
+/// Record describing a card unlock event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnlockRecord {
+    /// Identifier of the unlocked card.
+    pub card_id: Uuid,
+    /// Card owner identifier.
+    pub owner_id: Uuid,
+    /// Shared prefix (if any) used to enforce unlock limits.
+    pub parent_prefix: Option<String>,
+    /// The day the unlock happened.
+    pub day: NaiveDate,
+}
+
+/// Card data tracked by the scheduler.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Card {
+    /// Unique identifier.
+    pub id: Uuid,
+    /// Card owner.
+    pub owner_id: Uuid,
+    /// Card kind (opening or tactic).
+    pub kind: CardKind,
+    /// SRS state.
+    pub state: CardState,
+    /// Ease factor used by SM-2 calculations.
+    pub ease_factor: f32,
+    /// Current interval expressed in whole days.
+    pub interval_days: u32,
+    /// Due date for the next review.
+    pub due: NaiveDate,
+    /// Number of lapses (Again responses).
+    pub lapses: u32,
+    /// Total reviews recorded.
+    pub reviews: u32,
+}
+
+impl Card {
+    /// Create a brand new card using the provided configuration.
+    pub fn new(owner_id: Uuid, kind: CardKind, today: NaiveDate, config: &SchedulerConfig) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            owner_id,
+            kind,
+            state: CardState::New,
+            ease_factor: config.initial_ease_factor,
+            interval_days: 0,
+            due: today,
+            lapses: 0,
+            reviews: 0,
+        }
+    }
+}
+
+/// Outcome of a review operation, capturing the updated card and the diff applied.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewOutcome {
+    /// Updated card state after applying the review.
+    pub card: Card,
+    /// Previous due date prior to the review.
+    pub previous_due: NaiveDate,
+    /// Grade assigned during the review.
+    pub grade: ReviewGrade,
+}
+
+/// Errors that may occur while scheduling.
+#[derive(Debug, Error)]
+pub enum SchedulerError {
+    /// Attempted to review a card that does not exist.
+    #[error("card not found: {0}")]
+    CardNotFound(Uuid),
+}
+
+/// Trait describing persistence needs for the scheduler.
+pub trait CardStore {
+    /// Fetch a card by identifier.
+    fn get_card(&self, id: Uuid) -> Option<Card>;
+    /// Insert or update a card.
+    fn upsert_card(&mut self, card: Card);
+    /// Retrieve cards that are due on or before the provided day.
+    fn due_cards(&self, owner_id: Uuid, today: NaiveDate) -> Vec<Card>;
+    /// Fetch unlock candidates (typically brand new opening moves).
+    fn unlock_candidates(&self, owner_id: Uuid) -> Vec<Card>;
+    /// Record that a card was unlocked today.
+    fn record_unlock(&mut self, record: UnlockRecord);
+    /// Fetch unlock log entries for a particular day.
+    fn unlocked_on(&self, owner_id: Uuid, day: NaiveDate) -> Vec<UnlockRecord>;
+}
+
+/// In-memory card store useful for tests and examples.
+#[derive(Debug, Default)]
+pub struct InMemoryStore {
+    cards: BTreeMap<Uuid, Card>,
+    unlock_log: Vec<UnlockRecord>,
+}
+
+impl InMemoryStore {
+    /// Create an empty in-memory store.
+    pub fn new() -> Self {
+        Self {
+            cards: BTreeMap::new(),
+            unlock_log: Vec::new(),
+        }
+    }
+}
+
+impl CardStore for InMemoryStore {
+    fn get_card(&self, id: Uuid) -> Option<Card> {
+        self.cards.get(&id).cloned()
+    }
+
+    fn upsert_card(&mut self, card: Card) {
+        self.cards.insert(card.id, card);
+    }
+
+    fn due_cards(&self, owner_id: Uuid, today: NaiveDate) -> Vec<Card> {
+        let mut due: Vec<Card> = self
+            .cards
+            .values()
+            .filter(|card| {
+                card.owner_id == owner_id
+                    && card.due <= today
+                    && !matches!(card.state, CardState::New)
+            })
+            .cloned()
+            .collect();
+        due.sort_by(|a, b| (a.due, a.id).cmp(&(b.due, b.id)));
+        due
+    }
+
+    fn unlock_candidates(&self, owner_id: Uuid) -> Vec<Card> {
+        let mut candidates: Vec<Card> = self
+            .cards
+            .values()
+            .filter(|card| card.owner_id == owner_id && matches!(card.state, CardState::New))
+            .cloned()
+            .collect();
+        candidates.sort_by(|a, b| match (&a.kind, &b.kind) {
+            (
+                CardKind::Opening {
+                    parent_prefix: a_prefix,
+                },
+                CardKind::Opening {
+                    parent_prefix: b_prefix,
+                },
+            ) => (a_prefix, &a.id).cmp(&(b_prefix, &b.id)),
+            (CardKind::Opening { .. }, _) => std::cmp::Ordering::Less,
+            (_, CardKind::Opening { .. }) => std::cmp::Ordering::Greater,
+            _ => a.id.cmp(&b.id),
+        });
+        candidates
+    }
+
+    fn record_unlock(&mut self, record: UnlockRecord) {
+        self.unlock_log.push(record);
+    }
+
+    fn unlocked_on(&self, owner_id: Uuid, day: NaiveDate) -> Vec<UnlockRecord> {
+        self.unlock_log
+            .iter()
+            .filter(|record| record.owner_id == owner_id && record.day == day)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Scheduler applying SM-2 updates and unlock policy.
+#[derive(Debug)]
+pub struct Scheduler<S: CardStore> {
+    store: S,
+    config: SchedulerConfig,
+}
+
+impl<S: CardStore> Scheduler<S> {
+    /// Create a scheduler backed by the provided store and configuration.
+    pub fn new(store: S, config: SchedulerConfig) -> Self {
+        Self { store, config }
+    }
+
+    /// Apply a review for the specified card identifier.
+    pub fn review(
+        &mut self,
+        card_id: Uuid,
+        grade: ReviewGrade,
+        today: NaiveDate,
+    ) -> Result<ReviewOutcome, SchedulerError> {
+        let mut card = self
+            .store
+            .get_card(card_id)
+            .ok_or(SchedulerError::CardNotFound(card_id))?;
+        let previous_due = card.due;
+        apply_sm2(&mut card, grade, &self.config, today);
+        self.store.upsert_card(card.clone());
+        Ok(ReviewOutcome {
+            card,
+            previous_due,
+            grade,
+        })
+    }
+
+    /// Build a queue of cards due for the given day, including unlocks.
+    pub fn build_queue(&mut self, owner_id: Uuid, today: NaiveDate) -> Vec<Card> {
+        build_queue_for_day(&mut self.store, &self.config, owner_id, today)
+    }
+
+    /// Consume the scheduler and return the underlying store.
+    pub fn into_store(self) -> S {
+        self.store
+    }
+}
+
+/// Build a queue for the provided day by combining due cards and new unlocks.
+pub fn build_queue_for_day<S: CardStore>(
+    store: &mut S,
+    config: &SchedulerConfig,
+    owner_id: Uuid,
+    today: NaiveDate,
+) -> Vec<Card> {
+    let mut queue = store.due_cards(owner_id, today);
+    let prior_unlocks = store.unlocked_on(owner_id, today);
+    let mut unlocked_prefixes: BTreeSet<String> = prior_unlocks
+        .iter()
+        .filter_map(|record| record.parent_prefix.clone())
+        .collect();
+    let mut unlocked_ids: BTreeSet<Uuid> =
+        prior_unlocks.iter().map(|record| record.card_id).collect();
+
+    for mut candidate in store.unlock_candidates(owner_id) {
+        if unlocked_ids.contains(&candidate.id) {
+            continue;
+        }
+        let parent_prefix = match &candidate.kind {
+            CardKind::Opening { parent_prefix } => parent_prefix.clone(),
+            _ => continue,
+        };
+        if unlocked_prefixes.contains(&parent_prefix) {
+            continue;
+        }
+
+        candidate.state = CardState::Learning;
+        candidate.interval_days = 0;
+        candidate.due = today;
+        candidate.ease_factor = config.initial_ease_factor;
+        let record = UnlockRecord {
+            card_id: candidate.id,
+            owner_id,
+            parent_prefix: Some(parent_prefix.clone()),
+            day: today,
+        };
+        store.record_unlock(record);
+        unlocked_prefixes.insert(parent_prefix);
+        unlocked_ids.insert(candidate.id);
+        store.upsert_card(candidate.clone());
+        queue.push(candidate);
+    }
+
+    queue.sort_by(|a, b| (a.due, a.id).cmp(&(b.due, b.id)));
+    queue
+}
+
+fn apply_sm2(card: &mut Card, grade: ReviewGrade, config: &SchedulerConfig, today: NaiveDate) {
+    let previous_reviews = card.reviews;
+    let previous_interval = card.interval_days.max(1);
+    let ease = update_ease(card.ease_factor, grade, config);
+
+    let interval = match grade {
+        ReviewGrade::Again => {
+            card.lapses = card.lapses.saturating_add(1);
+            card.state = CardState::Relearning;
+            1
+        }
+        ReviewGrade::Hard => {
+            card.state = CardState::Review;
+            if previous_reviews == 0 {
+                1
+            } else if previous_reviews == 1 {
+                4
+            } else {
+                (((previous_interval as f32) * 1.2).round() as u32).max(1)
+            }
+        }
+        ReviewGrade::Good => {
+            card.state = CardState::Review;
+            if previous_reviews == 0 {
+                1
+            } else if previous_reviews == 1 {
+                6
+            } else {
+                (((previous_interval as f32) * ease).round() as u32).max(1)
+            }
+        }
+        ReviewGrade::Easy => {
+            card.state = CardState::Review;
+            if previous_reviews == 0 {
+                1
+            } else if previous_reviews == 1 {
+                6
+            } else {
+                (((previous_interval as f32) * (ease * 1.3)).round() as u32).max(1)
+            }
+        }
+    };
+
+    let due = today
+        .checked_add_signed(Duration::days(i64::from(interval)))
+        .unwrap_or(today);
+    card.due = due;
+    card.interval_days = interval;
+    card.ease_factor = ease;
+    card.reviews = card.reviews.saturating_add(1);
+}
+
+fn update_ease(current: f32, grade: ReviewGrade, config: &SchedulerConfig) -> f32 {
+    let quality = match grade {
+        ReviewGrade::Again => 0.0,
+        ReviewGrade::Hard => 3.0,
+        ReviewGrade::Good => 4.0,
+        ReviewGrade::Easy => 5.0,
+    };
+    let delta = 0.1 - (5.0 - quality) * (0.08 + (5.0 - quality) * 0.02);
+    let next = current + delta;
+    next.clamp(config.ease_minimum, config.ease_maximum)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_ease_clamps_values() {
+        let config = SchedulerConfig {
+            initial_ease_factor: 2.0,
+            ease_minimum: 1.4,
+            ease_maximum: 2.3,
+            learning_steps_minutes: vec![],
+        };
+        assert!((update_ease(2.5, ReviewGrade::Hard, &config) - 2.3).abs() < f32::EPSILON);
+        assert!((update_ease(1.0, ReviewGrade::Again, &config) - 1.4).abs() < f32::EPSILON);
+    }
+}

--- a/crates/scheduler-core/src/main.rs
+++ b/crates/scheduler-core/src/main.rs
@@ -1,3 +1,1 @@
-fn main() {
-    println!("Hello, world!");
-}
+fn main() {}

--- a/crates/scheduler-core/tests/scheduler_sm2.rs
+++ b/crates/scheduler-core/tests/scheduler_sm2.rs
@@ -1,0 +1,133 @@
+use chrono::NaiveDate;
+use scheduler_core::{
+    Card, CardKind, CardState, CardStore, InMemoryStore, ReviewGrade, Scheduler, SchedulerConfig,
+    build_queue_for_day,
+};
+use uuid::Uuid;
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).expect("invalid date")
+}
+
+#[test]
+fn sm2_good_review_promotes_new_card() {
+    let mut store = InMemoryStore::new();
+    let config = SchedulerConfig::default();
+    let owner = Uuid::new_v4();
+    let today = date(2024, 1, 1);
+    let card = Card::new(owner, CardKind::Tactic, today, &config);
+    let card_id = card.id;
+    store.upsert_card(card);
+
+    let mut scheduler = Scheduler::new(store, config.clone());
+    let outcome = scheduler
+        .review(card_id, ReviewGrade::Good, today)
+        .expect("review should succeed");
+
+    assert_eq!(outcome.card.state, CardState::Review);
+    assert_eq!(outcome.card.interval_days, 1);
+    assert_eq!(outcome.card.due, today.succ_opt().unwrap());
+    assert_eq!(outcome.card.reviews, 1);
+
+    let store = scheduler.into_store();
+    let stored = store.get_card(card_id).expect("card persisted");
+    assert_eq!(stored, outcome.card);
+}
+
+#[test]
+fn sm2_again_resets_interval_and_ease() {
+    let mut store = InMemoryStore::new();
+    let mut config = SchedulerConfig::default();
+    config.ease_minimum = 1.5;
+    let owner = Uuid::new_v4();
+    let today = date(2024, 2, 2);
+
+    let mut card = Card::new(owner, CardKind::Tactic, today, &config);
+    card.state = CardState::Review;
+    card.interval_days = 10;
+    card.due = today;
+    card.ease_factor = 2.4;
+    card.reviews = 5;
+    let card_id = card.id;
+    store.upsert_card(card);
+
+    let mut scheduler = Scheduler::new(store, config.clone());
+    let outcome = scheduler
+        .review(card_id, ReviewGrade::Again, today)
+        .expect("review should succeed");
+
+    assert_eq!(outcome.card.state, CardState::Relearning);
+    assert_eq!(outcome.card.interval_days, 1);
+    assert_eq!(outcome.card.due, today.succ_opt().unwrap());
+    assert_eq!(outcome.card.lapses, 1);
+    assert!(outcome.card.ease_factor >= config.ease_minimum);
+    assert!(outcome.card.ease_factor < 2.4);
+}
+
+#[test]
+fn unlocks_one_opening_per_prefix_per_day() {
+    let mut store = InMemoryStore::new();
+    let config = SchedulerConfig::default();
+    let owner = Uuid::new_v4();
+    let today = date(2024, 3, 3);
+
+    // Existing due review card.
+    let mut due_card = Card::new(owner, CardKind::Tactic, today, &config);
+    due_card.state = CardState::Review;
+    due_card.due = today;
+    store.upsert_card(due_card.clone());
+
+    // Unlock candidates.
+    let opening_a1 = Card::new(
+        owner,
+        CardKind::Opening {
+            parent_prefix: "e4 e5".to_string(),
+        },
+        today,
+        &config,
+    );
+    let opening_a2 = Card::new(
+        owner,
+        CardKind::Opening {
+            parent_prefix: "e4 e5".to_string(),
+        },
+        today,
+        &config,
+    );
+    let opening_b = Card::new(
+        owner,
+        CardKind::Opening {
+            parent_prefix: "d4 d5".to_string(),
+        },
+        today,
+        &config,
+    );
+
+    for card in [&opening_a1, &opening_a2, &opening_b] {
+        store.upsert_card(card.clone());
+    }
+
+    let mut scheduler = Scheduler::new(store, config.clone());
+    let first_queue = scheduler.build_queue(owner, today);
+    assert_eq!(first_queue.len(), 3, "one due + two unlocked openings");
+
+    let unlocked: Vec<_> = first_queue
+        .iter()
+        .filter(|card| card.state == CardState::Learning)
+        .collect();
+    assert_eq!(unlocked.len(), 2);
+
+    let prefixes: Vec<_> = unlocked
+        .iter()
+        .map(|card| match &card.kind {
+            CardKind::Opening { parent_prefix } => parent_prefix.clone(),
+            _ => panic!("expected opening"),
+        })
+        .collect();
+    assert_eq!(prefixes.len(), 2);
+    assert_ne!(prefixes[0], prefixes[1], "prefixes must be unique");
+
+    let mut store = scheduler.into_store();
+    let second_queue = build_queue_for_day(&mut store, &config, owner, today);
+    assert_eq!(second_queue.len(), 3, "no additional unlocks on same day");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
 fn main() {
     println!("Hello, world!");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn main_runs_without_panicking() {
+        main();
+    }
+}


### PR DESCRIPTION
## Summary
- build the scheduler-core library with SM-2 scheduling, unlock policy, and an in-memory store implementation
- add integration tests covering review updates and prefix-limited unlock behaviour
- configure crate dependencies and ensure the workspace main binary is covered during testing

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e6492015088325abe5c459a1c1e301

## Summary by Sourcery

Implement scheduler-core library with SM-2 spaced repetition engine, one-per-prefix unlock policy, and an in-memory store, and add comprehensive tests and dependency configuration

New Features:
- Implement SM-2 algorithm for spaced repetition reviews in scheduler-core
- Introduce unlock policy to limit one new opening card per prefix per day
- Provide an in‐memory CardStore implementation and expose Scheduler API with review and queue building functions

Build:
- Update Cargo.toml with core and dev dependencies (chrono, thiserror, uuid, maplit) and configure workspace testing

Tests:
- Add unit tests for ease factor clamping and integration tests for review outcomes and unlock behavior