### PR TITLE
feat(web-ui): add session gateway integration and store

### DIFF
--- a/web-ui/src/App.css
+++ b/web-ui/src/App.css
@@ -201,3 +201,48 @@
     align-self: flex-end;
   }
 }
+}
+
+.review-controls {
+  margin-top: var(--space-gap-large);
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.review-controls h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.grade-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.grade-buttons button {
+  border: none;
+  border-radius: var(--radius-medium);
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--color-accent-primary);
+  color: var(--color-surface);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.grade-buttons button:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated);
+}
+
+.grade-buttons button:active {
+  transform: translateY(1px);
+  box-shadow: none;
+}

--- a/web-ui/src/App.test.tsx
+++ b/web-ui/src/App.test.tsx
@@ -1,13 +1,109 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createDefaultStats() {
+  return {
+    reviews_today: 3,
+    accuracy: 0.75,
+    avg_latency_ms: 1800,
+    due_count: 12,
+    completed_count: 9,
+  };
+}
+
+vi.mock('./state/sessionStore', () => {
+  const listeners = new Set<(state: unknown) => void>();
+  const state = {
+    sessionId: 's1',
+    queue: [],
+    currentCard: {
+      card_id: 'c1',
+      kind: 'Opening',
+      position_fen: 'start',
+      prompt: 'Play the move',
+    },
+    stats: createDefaultStats(),
+    start: vi.fn(),
+    submitGrade: vi.fn(),
+    nextCard: vi.fn(),
+  };
+
+  return {
+    sessionStore: {
+      getState: () => state,
+      subscribe: (listener: (state: unknown) => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+  };
+});
 
 import App from './App';
+import { sessionStore } from './state/sessionStore';
+
+const mockedStore = sessionStore as unknown as {
+  getState: () => {
+    start: ReturnType<typeof vi.fn>;
+    submitGrade: ReturnType<typeof vi.fn>;
+    stats: ReturnType<typeof createDefaultStats> | undefined;
+  } & Record<string, unknown>;
+};
+
+beforeEach(() => {
+  const state = mockedStore.getState();
+  state.start.mockClear();
+  state.submitGrade.mockClear();
+  state.stats = createDefaultStats();
+});
 
 describe('App', () => {
-  it('renders the review dashboard with sample data', () => {
+  it('starts the session on mount and renders live stats', async () => {
     render(<App />);
 
+    await waitFor(() => {
+      expect(mockedStore.getState().start).toHaveBeenCalled();
+    });
     expect(screen.getByRole('heading', { name: /Daily Review Summary/i })).toBeInTheDocument();
-    expect(screen.getByText(/Upcoming Unlocks/i)).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
+  });
+
+  it('submits a grade when clicking a grade button', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: /Good/i }));
+
+    expect(mockedStore.getState().submitGrade).toHaveBeenCalledWith('Good', expect.any(Number));
+  });
+
+  it('falls back to the baseline overview when stats are unavailable', async () => {
+    mockedStore.getState().stats = undefined;
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedStore.getState().start).toHaveBeenCalled();
+    });
+    expect(screen.getByText('18')).toBeInTheDocument();
+    expect(screen.getByText('11')).toBeInTheDocument();
+  });
+
+  it('treats zero due counts as fully complete', async () => {
+    mockedStore.getState().stats = {
+      ...createDefaultStats(),
+      due_count: 0,
+      completed_count: 0,
+    };
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedStore.getState().start).toHaveBeenCalled();
+    });
+    const dueCard = screen.getByText('Due Today').closest('.metric-card');
+    expect(dueCard).not.toBeNull();
+    expect(within(dueCard as HTMLElement).getByText('0')).toBeInTheDocument();
+    expect(screen.getByText(/100% complete/i)).toBeInTheDocument();
   });
 });

--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -1,18 +1,83 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 
 import './App.css';
 import { ReviewDashboard } from './components/ReviewDashboard';
 import { sampleSnapshot } from './fixtures/sampleSnapshot';
 import { ReviewPlanner } from './services/ReviewPlanner';
+import type { ReviewGrade } from './types/gateway';
+import { sessionStore } from './state/sessionStore';
 
 const planner = new ReviewPlanner();
 
+const gradeLabels: ReviewGrade[] = ['Again', 'Hard', 'Good', 'Easy'];
+
+function useSessionState() {
+  return useSyncExternalStore(sessionStore.subscribe, sessionStore.getState, sessionStore.getState);
+}
+
 function App(): JSX.Element {
-  const overview = useMemo(() => planner.buildOverview(sampleSnapshot), []);
+  const session = useSessionState();
+  const { stats, currentCard, start, submitGrade } = session;
+  const startedAtRef = useRef<number>(performance.now());
+
+  const baselineOverview = useMemo(() => planner.buildOverview(sampleSnapshot), []);
+  const overview = useMemo(() => {
+    if (!stats) {
+      return baselineOverview;
+    }
+
+    const totalDue = stats.due_count;
+    const completed = stats.completed_count;
+    const remaining = Math.max(totalDue - completed, 0);
+    const completionRate = totalDue === 0 ? 1 : completed / totalDue;
+
+    return {
+      ...baselineOverview,
+      progress: {
+        ...baselineOverview.progress,
+        totalDue,
+        completedToday: completed,
+        remaining,
+        completionRate,
+        accuracyRate: stats.accuracy,
+      },
+    };
+  }, [baselineOverview, stats]);
+
+  useEffect(() => {
+    void start('demo-user');
+  }, [start]);
+
+  useEffect(() => {
+    if (currentCard) {
+      startedAtRef.current = performance.now();
+    }
+  }, [currentCard]);
+
+  const handleGrade = (grade: ReviewGrade) => {
+    const latency = Math.max(0, Math.round(performance.now() - startedAtRef.current));
+    void submitGrade(grade, latency);
+  };
 
   return (
     <main className="app-shell">
       <ReviewDashboard overview={overview} />
+      <section aria-label="Review controls" className="review-controls">
+        <h2>Grade Current Card</h2>
+        <div className="grade-buttons">
+          {gradeLabels.map((grade) => (
+            <button
+              key={grade}
+              type="button"
+              onClick={() => {
+                handleGrade(grade);
+              }}
+            >
+              {grade}
+            </button>
+          ))}
+        </div>
+      </section>
     </main>
   );
 }

--- a/web-ui/src/clients/__tests__/sessionGateway.test.ts
+++ b/web-ui/src/clients/__tests__/sessionGateway.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sessionGateway } from '../sessionGateway';
+
+const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+
+describe('sessionGateway', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts a session with the expected payload', async () => {
+    const responseBody = { session_id: 's1', queue_size: 3, first_card: { card_id: 'c1' } };
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const result = await sessionGateway.startSession('user-1');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/session/start',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ user_id: 'user-1' }),
+      }),
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.headers).toBeInstanceOf(Headers);
+    expect((init?.headers as Headers).get('content-type')).toBe('application/json');
+    expect(result).toEqual(responseBody);
+  });
+
+  it('throws when startSession fails', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 500 }));
+
+    await expect(sessionGateway.startSession('user-2')).rejects.toThrow('/api/session/start failed: 500');
+  });
+
+  it('submits a grade and returns the next card', async () => {
+    const responseBody = { next_card: { card_id: 'c2' } };
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const result = await sessionGateway.grade('c1', 'Good', 4500);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/session/grade',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ card_id: 'c1', grade: 'Good', latency_ms: 4500 }),
+      }),
+    );
+    const [, gradeInit] = fetchMock.mock.calls[0];
+    expect(gradeInit?.headers).toBeInstanceOf(Headers);
+    expect((gradeInit?.headers as Headers).get('content-type')).toBe('application/json');
+    expect(result).toEqual(responseBody);
+  });
+
+  it('throws when grade fails', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 400 }));
+
+    await expect(sessionGateway.grade('c9', 'Again', 1000)).rejects.toThrow('/api/session/grade failed: 400');
+  });
+
+  it('fetches stats', async () => {
+    const responseBody = { reviews_today: 3 };
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const result = await sessionGateway.stats();
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/session/stats', undefined);
+    expect(result).toEqual(responseBody);
+  });
+
+  it('throws when stats fails', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+    await expect(sessionGateway.stats()).rejects.toThrow('/api/session/stats failed: 404');
+  });
+});

--- a/web-ui/src/clients/sessionGateway.ts
+++ b/web-ui/src/clients/sessionGateway.ts
@@ -1,0 +1,47 @@
+import type { CardSummary, ReviewGrade, SessionStats, StartSessionResponse } from '../types/gateway';
+
+/* c8 ignore next 2 */
+const env = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+const baseUrlFromEnv = env && typeof env.VITE_SESSION_URL === 'string' ? env.VITE_SESSION_URL : undefined;
+const BASE_URL: string = baseUrlFromEnv ?? 'http://localhost:3000';
+
+type JsonShape<T> = T;
+
+type RequestConfig = Omit<RequestInit, 'body'> & { body?: Record<string, unknown> };
+
+async function request<T>(path: string, init?: RequestConfig): Promise<JsonShape<T>> {
+  const config = init?.body ? normalizeConfig(init) : init;
+  const response = await fetch(`${BASE_URL}${path}`, config);
+  if (!response.ok) {
+    throw new Error(`${path} failed: ${String(response.status)}`);
+  }
+  return (await response.json()) as T;
+}
+
+function normalizeConfig(init: RequestConfig): RequestInit {
+  const headers = new Headers(init.headers);
+  headers.set('content-type', 'application/json');
+  return {
+    ...init,
+      body: JSON.stringify(init.body),
+      headers,
+    } satisfies RequestInit;
+  }
+
+export const sessionGateway = {
+  startSession(userId: string): Promise<StartSessionResponse> {
+    return request<StartSessionResponse>('/api/session/start', {
+      method: 'POST',
+      body: { user_id: userId },
+    });
+  },
+  grade(cardId: string, gradeValue: ReviewGrade, latencyMs: number): Promise<{ next_card?: CardSummary }> {
+    return request<{ next_card?: CardSummary }>('/api/session/grade', {
+      method: 'POST',
+      body: { card_id: cardId, grade: gradeValue, latency_ms: latencyMs },
+    });
+  },
+  stats(): Promise<SessionStats> {
+    return request<SessionStats>('/api/session/stats');
+  },
+} as const;

--- a/web-ui/src/state/__tests__/sessionStore.test.ts
+++ b/web-ui/src/state/__tests__/sessionStore.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../clients/sessionGateway', () => ({
+  sessionGateway: {
+    startSession: vi.fn(),
+    grade: vi.fn(),
+    stats: vi.fn(),
+  },
+}));
+
+import type { CardSummary, SessionStats, StartSessionResponse } from '../../types/gateway';
+import { sessionGateway } from '../../clients/sessionGateway';
+import { sessionStore } from '../sessionStore';
+
+const gateway = sessionGateway as unknown as {
+  startSession: ReturnType<typeof vi.fn>;
+  grade: ReturnType<typeof vi.fn>;
+  stats: ReturnType<typeof vi.fn>;
+};
+
+const stubCard: CardSummary = {
+  card_id: 'c1',
+  kind: 'Opening',
+  position_fen: 'start',
+  prompt: 'Play the move',
+};
+
+const stubStats: SessionStats = {
+  reviews_today: 1,
+  accuracy: 0.5,
+  avg_latency_ms: 1500,
+  due_count: 10,
+  completed_count: 2,
+};
+
+beforeEach(() => {
+  gateway.startSession.mockReset();
+  gateway.grade.mockReset();
+  gateway.stats.mockReset();
+  sessionStore.setState({ sessionId: undefined, currentCard: undefined, queue: [], stats: undefined });
+});
+
+describe('sessionStore', () => {
+  it('starts a session and loads stats', async () => {
+    const response: StartSessionResponse = { session_id: 's1', queue_size: 3, first_card: stubCard };
+    gateway.startSession.mockResolvedValue(response);
+    gateway.stats.mockResolvedValue(stubStats);
+
+    await sessionStore.getState().start('user-1');
+
+    expect(gateway.startSession).toHaveBeenCalledWith('user-1');
+    expect(sessionStore.getState().sessionId).toBe('s1');
+    expect(sessionStore.getState().currentCard).toEqual(stubCard);
+    expect(sessionStore.getState().stats).toEqual(stubStats);
+  });
+
+  it('submits a grade, advances to the next card, and refreshes stats', async () => {
+    const refreshedStats: SessionStats = { ...stubStats, completed_count: 3 };
+    gateway.grade.mockResolvedValue({ next_card: { ...stubCard, card_id: 'c2' } });
+    gateway.stats.mockResolvedValue(refreshedStats);
+    sessionStore.setState({ sessionId: 's1', currentCard: stubCard, stats: stubStats });
+
+    await sessionStore.getState().submitGrade('Good', 3200);
+
+    expect(gateway.grade).toHaveBeenCalledWith('c1', 'Good', 3200);
+    expect(sessionStore.getState().currentCard?.card_id).toBe('c2');
+    expect(sessionStore.getState().stats).toEqual(refreshedStats);
+  });
+
+  it('ignores grade submissions when no card is active', async () => {
+    await sessionStore.getState().submitGrade('Good', 1500);
+
+    expect(gateway.grade).not.toHaveBeenCalled();
+  });
+
+  it('allows subscribers to unsubscribe from updates', () => {
+    const listener = vi.fn();
+    const unsubscribe = sessionStore.subscribe(listener);
+
+    sessionStore.setState({ stats: stubStats });
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ stats: stubStats }));
+
+    listener.mockClear();
+    unsubscribe();
+    sessionStore.setState({ stats: { ...stubStats, completed_count: 5 } });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/src/state/sessionStore.ts
+++ b/web-ui/src/state/sessionStore.ts
@@ -1,0 +1,73 @@
+import { sessionGateway } from '../clients/sessionGateway';
+import type { CardSummary, ReviewGrade, SessionStats } from '../types/gateway';
+
+type SessionStoreState = {
+  sessionId?: string;
+  queue: CardSummary[];
+  currentCard?: CardSummary;
+  stats?: SessionStats;
+  start: (userId: string) => Promise<void>;
+  submitGrade: (grade: ReviewGrade, latencyMs: number) => Promise<void>;
+  nextCard: (card?: CardSummary) => void;
+};
+
+type InternalState = Omit<SessionStoreState, 'start' | 'submitGrade' | 'nextCard'>;
+
+type Listener = (state: SessionStoreState) => void;
+
+const listeners = new Set<Listener>();
+
+const baseState: InternalState = {
+  sessionId: undefined,
+  queue: [],
+  currentCard: undefined,
+  stats: undefined,
+};
+
+let state: SessionStoreState = {
+  ...baseState,
+  start: async (userId: string) => {
+    const [session, sessionStats] = await Promise.all([
+      sessionGateway.startSession(userId),
+      sessionGateway.stats(),
+    ]);
+    setState({
+      sessionId: session.session_id,
+      queue: [],
+      currentCard: session.first_card,
+      stats: sessionStats,
+    });
+  },
+  submitGrade: async (gradeValue: ReviewGrade, latencyMs: number) => {
+    if (!state.currentCard) {
+      return;
+    }
+    const result = await sessionGateway.grade(state.currentCard.card_id, gradeValue, latencyMs);
+    state.nextCard(result.next_card);
+    const updatedStats = await sessionGateway.stats();
+    setState({ stats: updatedStats });
+  },
+  nextCard: (card?: CardSummary) => {
+    setState({ currentCard: card });
+  },
+};
+
+function setState(partial: Partial<InternalState>): void {
+  state = { ...state, ...partial };
+  listeners.forEach((listener) => {
+    listener(state);
+  });
+}
+
+export const sessionStore = {
+  getState: (): SessionStoreState => state,
+  setState: (partial: Partial<InternalState>) => {
+    setState(partial);
+  },
+  subscribe: (listener: Listener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+};

--- a/web-ui/src/types/gateway.ts
+++ b/web-ui/src/types/gateway.ts
@@ -1,0 +1,27 @@
+export type ReviewGrade = 'Again' | 'Hard' | 'Good' | 'Easy';
+
+export type CardKind = 'Opening' | 'Tactic';
+
+export type CardSummary = {
+  card_id: string;
+  kind: CardKind;
+  position_fen: string;
+  prompt: string;
+  expected_moves_uci?: string[];
+  pv_uci?: string[];
+  meta?: Record<string, string | number>;
+};
+
+export type SessionStats = {
+  reviews_today: number;
+  accuracy: number;
+  avg_latency_ms: number;
+  due_count: number;
+  completed_count: number;
+};
+
+export type StartSessionResponse = {
+  session_id: string;
+  queue_size: number;
+  first_card: CardSummary;
+};


### PR DESCRIPTION
## Summary
- add a typed session gateway client and shared gateway types to replace fixture wiring
- introduce a session state store that starts sessions, submits grades, and refreshes dashboard stats
- render live metrics in the app shell with new grading controls and supporting styles/tests

## Testing
- npm --prefix web-ui run lint
- npm --prefix web-ui run typecheck
- npm --prefix web-ui run test:coverage
- make test *(fails: existing card-store inmemory_store tests reject invalid FEN inputs)*

------
https://chatgpt.com/codex/tasks/task_e_68e66ed27468832580d415c2648d3f42