### PR TITLE
Refactor storage modules into focused units

### DIFF
--- a/crates/scheduler-core/src/sm2.rs
+++ b/crates/scheduler-core/src/sm2.rs
@@ -98,7 +98,7 @@ fn state_after_grade(current: CardState, grade: ReviewGrade) -> CardState {
         ReviewGrade::Again => CardState::Relearning,
         ReviewGrade::Hard | ReviewGrade::Good | ReviewGrade::Easy => match current {
             CardState::New | CardState::Learning => CardState::Review,
-            other => other,
+            current_state => current_state,
         },
     }
 }


### PR DESCRIPTION
## Summary
- split the card-store in-memory backend into small helper modules with exhaustive unit tests and add a README describing the layout
- modularize the scheduler-core crate into dedicated config, domain, queue, SM-2, and storage modules with colocated tests and refreshed documentation
- tighten the chess-training-pgn-import IoError test to downcast the captured source error explicitly

## Testing
- make test *(fails: cargo llvm-cov is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6b87edd40832592fb3e5a9ddf4dec

## Summary by Sourcery

Refactor scheduler-core and card-store crates into fine-grained modules with dedicated helper functions, colocated tests, and documentation, and refine error handling in the PGN importer test

Bug Fixes:
- Tighten chess-training-pgn-import IO error test to explicitly downcast the source error

Enhancements:
- Split scheduler-core library into config, domain, errors, grade, queue, scheduler, sm2, and store modules
- Break out in-memory CardStore implementation into focused positions, edges, cards, reviews, and unlocks submodules

Documentation:
- Add README for scheduler-core modular layout
- Add README for in-memory card-store helper modules

Tests:
- Co-locate exhaustive unit tests alongside each new helper module
- Add new tests for memory store operations and queue building