### PR TITLE
Refine command console transitions

### DIFF
--- a/web-ui/src/components/CommandConsole.css
+++ b/web-ui/src/components/CommandConsole.css
@@ -1,0 +1,211 @@
+
+.command-console-launcher {
+  position: fixed;
+  bottom: 1.75rem;
+  right: 1.75rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(145deg, rgba(78, 115, 255, 0.95), rgba(48, 82, 231, 0.95));
+  color: #fff;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 18px 32px rgba(14, 21, 42, 0.45);
+  transition: transform 180ms ease, opacity 200ms ease, box-shadow 180ms ease;
+  z-index: 1001;
+}
+
+.command-console-launcher:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 4px;
+}
+
+.command-console-launcher:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 22px 36px rgba(14, 21, 42, 0.48);
+}
+
+.command-console-launcher--active {
+  opacity: 0;
+  transform: translateY(14px) scale(0.85);
+  pointer-events: none;
+}
+
+.command-console-launcher__icon {
+  font-family: 'Source Code Pro', 'Fira Code', monospace;
+}
+
+.command-console-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 0 1.5rem;
+  background: rgba(3, 6, 20, 0.55);
+  z-index: 1000;
+  animation: command-console-fade-in 200ms ease-out forwards;
+}
+
+.command-console-overlay--closing {
+  animation: command-console-fade-out 200ms ease-in forwards;
+  pointer-events: none;
+}
+
+.command-console {
+  width: min(960px, 100%);
+  background: rgba(12, 16, 36, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: none;
+  border-radius: var(--radius-large) var(--radius-large) 0 0;
+  box-shadow: 0 -24px 48px rgba(3, 6, 20, 0.55);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  transform: translateY(100%);
+  animation: command-console-slide-up 240ms ease-out forwards;
+  position: relative;
+}
+
+.command-console--closing {
+  animation: command-console-slide-down 240ms ease-in forwards;
+}
+
+.command-console__container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem 1.75rem 1.75rem;
+  min-height: clamp(200px, 25vh, 320px);
+}
+
+.command-console__close {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(18, 24, 46, 0.85);
+  color: var(--color-text-primary);
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.command-console__close:hover {
+  transform: scale(1.05);
+  background: rgba(28, 34, 58, 0.95);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.command-console__close:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.command-console__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+}
+
+.command-console__title {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.command-console__hint {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+}
+
+.command-console__body {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(7, 10, 26, 0.65);
+  min-height: 4rem;
+}
+
+.command-console__prompt {
+  font-family: 'Source Code Pro', 'Fira Code', monospace;
+  font-size: 1.35rem;
+  line-height: 1;
+  color: var(--color-text-primary);
+}
+
+.command-console__placeholder {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 600px) {
+  .command-console-overlay {
+    padding: 0 1rem;
+  }
+
+  .command-console__container {
+    padding: 1.25rem 1.25rem 1.5rem;
+  }
+
+  .command-console__body {
+    padding: 0.75rem 1rem;
+  }
+}
+
+@keyframes command-console-slide-up {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes command-console-slide-down {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes command-console-fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes command-console-fade-out {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/web-ui/src/components/CommandConsole.tsx
+++ b/web-ui/src/components/CommandConsole.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import './CommandConsole.css';
+
+type CommandConsoleProps = {
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+const CONSOLE_ANIMATION_DURATION_MS = 240;
+
+export const CommandConsole = ({ isOpen, onOpen, onClose }: CommandConsoleProps) => {
+  const [isRendered, setIsRendered] = useState(isOpen);
+  const [isClosing, setIsClosing] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsRendered(true);
+      setIsClosing(false);
+      return;
+    }
+
+    if (!isRendered) {
+      return;
+    }
+
+    setIsClosing(true);
+    const timeout = window.setTimeout(() => {
+      setIsRendered(false);
+      setIsClosing(false);
+    }, CONSOLE_ANIMATION_DURATION_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isOpen, isRendered]);
+
+  const launcherClassName = useMemo(() => {
+    const classNames = ['command-console-launcher'];
+    if (isRendered) {
+      classNames.push('command-console-launcher--active');
+    }
+    return classNames.join(' ');
+  }, [isRendered]);
+
+  const overlayClassName = useMemo(() => {
+    const classNames = ['command-console-overlay'];
+    if (isClosing) {
+      classNames.push('command-console-overlay--closing');
+    }
+    return classNames.join(' ');
+  }, [isClosing]);
+
+  const consoleClassName = useMemo(() => {
+    const classNames = ['command-console'];
+    if (isClosing) {
+      classNames.push('command-console--closing');
+    }
+    return classNames.join(' ');
+  }, [isClosing]);
+
+  const isVisible = isOpen || isClosing;
+
+  return (
+    <>
+      <button
+        type="button"
+        className={launcherClassName}
+        onClick={isVisible ? onClose : onOpen}
+        aria-label={isVisible ? 'Close command console' : 'Open command console'}
+        aria-expanded={isVisible}
+      >
+        <span className="command-console-launcher__icon">{isVisible ? '×' : '$:'}</span>
+      </button>
+      {isRendered && (
+        <div className={overlayClassName}>
+          <div className={consoleClassName} role="dialog" aria-label="Command console" aria-modal="true">
+            <button
+              type="button"
+              className="command-console__close"
+              onClick={onClose}
+              aria-label="Close command console"
+            >
+              ×
+            </button>
+            <div className="command-console__container">
+              <div className="command-console__header">
+                <span className="command-console__title">Command Console</span>
+                <span className="command-console__hint">Press Esc or click × to close</span>
+              </div>
+              <div className="command-console__body">
+                <span className="command-console__prompt">$:</span>
+                <span className="command-console__placeholder">Awaiting commands…</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- keep the launcher hidden until the overlay finishes animating and reuse it for both opening and closing actions
- add close-state animation handling so the console and scrim slide back to the bottom instead of disappearing abruptly
- tweak overlay keyframes and timing to preserve the slide-from-bottom effect while removing the lingering blur

## Testing
- npm run test --prefix web-ui -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e6e6fb4d38832592df839ee97582a9