### PR TITLE
Add test coverage for command console and scheduler gateway flows

### DIFF
--- a/apps/session-gateway/tests/httpSchedulerClient.test.ts
+++ b/apps/session-gateway/tests/httpSchedulerClient.test.ts
@@ -92,10 +92,10 @@ describe('http scheduler client', () => {
   it('treats missing queue payloads as empty results', async () => {
     const fetchMock = vi.fn();
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }));
-    const client = createHttpSchedulerClient({
-      baseUrl: 'http://scheduler.test',
-      fetchImpl: fetchMock,
-    });
+    const client = createClient(fetchMock);
+    await expect(client.fetchQueue('user-1')).resolves.toEqual([]);
+  });
+
   it('returns an empty queue when the scheduler omits the queue field', async () => {
     const fetchMock = vi.fn();
     // Response missing the 'queue' field

--- a/apps/session-gateway/tests/sessionGateway.test.ts
+++ b/apps/session-gateway/tests/sessionGateway.test.ts
@@ -279,19 +279,21 @@ describe('session gateway', () => {
     await gradeCard(baseUrl, sessionId, 'c123', 'Good');
 
     await new Promise((resolve) => setTimeout(resolve, 50));
-    const updateMessage = messages.find(
+    const initialUpdateMessage = messages.find(
       (msg) => (msg as { type: string }).type === 'UPDATE',
     );
-    expect(updateMessage).toBeTruthy();
-    expect(updateMessage).toMatchObject({
+    expect(initialUpdateMessage).toBeTruthy();
+    expect(initialUpdateMessage).toMatchObject({
       type: 'UPDATE',
       card: expect.objectContaining({ card_id: 'c456' }),
       stats: expect.objectContaining({ reviews_today: 1 }),
     });
     await wait();
-    const updateMessage = messages.find((msg) => (msg as { type: string }).type === 'UPDATE');
-    expect(updateMessage).toBeTruthy();
-    expect((updateMessage as { stats?: unknown })?.stats).toBeTruthy();
+    const statsUpdateMessage = messages.find(
+      (msg) => (msg as { type: string }).type === 'UPDATE',
+    );
+    expect(statsUpdateMessage).toBeTruthy();
+    expect((statsUpdateMessage as { stats?: unknown })?.stats).toBeTruthy();
     socket.close();
     await waitForClose(socket);
   });

--- a/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
+++ b/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Chess } from 'chess.js';
 
 import type { CardSummary } from '../../types/gateway';
@@ -35,7 +35,7 @@ describe('OpeningReviewBoard', () => {
     const onResult = vi.fn();
     render(<OpeningReviewBoard card={baseCard} onResult={onResult} />);
 
-    const shortcut = screen.getByRole('link', { name: /open position on lichess/i });
+    const shortcut = screen.getByRole('link', { name: /analyze this position on lichess/i });
     expect(shortcut).toHaveAttribute(
       'href',
       `https://lichess.org/analysis/standard/${encodeURIComponent(baseCard.position_fen)}`,
@@ -135,6 +135,18 @@ describe('OpeningReviewBoard', () => {
       expected_moves_uci: ['d7d8q'],
     };
     render(<OpeningReviewBoard card={promotionCard} onResult={onResult} />);
+
+    const board = screen.getByTestId('opening-review-board');
+
+    board.dispatchEvent(
+      new CustomEvent('drop', {
+        detail: { source: 'd7', target: 'd8', promotion: 'q' },
+      }),
+    );
+
+    expect(onResult).toHaveBeenCalledWith('Good', expect.any(Number));
+  });
+
   it('shows a teaching arrow for the first move of a new line', () => {
     const onResult = vi.fn();
     render(<OpeningReviewBoard card={italianStart} onResult={onResult} />);
@@ -142,6 +154,32 @@ describe('OpeningReviewBoard', () => {
     const board = screen.getByTestId('opening-review-board');
 
     expect(board.getAttribute('data-teaching-arrow')).toBe('e2e4');
+  });
+
+  it('omits the teaching arrow when the metadata does not provide a string value', () => {
+    const onResult = vi.fn();
+    const numericTeachingMeta: CardSummary = {
+      ...baseCard,
+      meta: { teaching_move_uci: 42 },
+    };
+
+    render(<OpeningReviewBoard card={numericTeachingMeta} onResult={onResult} />);
+
+    const board = screen.getByTestId('opening-review-board');
+    expect(board.hasAttribute('data-teaching-arrow')).toBe(false);
+  });
+
+  it('suppresses the teaching arrow once the line has existing reviews', () => {
+    const onResult = vi.fn();
+    const reviewedLineCard: CardSummary = {
+      ...baseCard,
+      meta: { teaching_move_uci: 'c2c4', line_reviews: 3 },
+    };
+
+    render(<OpeningReviewBoard card={reviewedLineCard} onResult={onResult} />);
+
+    const board = screen.getByTestId('opening-review-board');
+    expect(board.hasAttribute('data-teaching-arrow')).toBe(false);
   });
 
   it('updates the teaching arrow when presenting the follow-up move', () => {
@@ -165,14 +203,11 @@ describe('OpeningReviewBoard', () => {
 
     board.dispatchEvent(
       new CustomEvent('drop', {
-        detail: { source: 'd7', target: 'd8', promotion: 'q' },
-      }),
-    );
-
-    expect(onResult).toHaveBeenCalledWith('Good', expect.any(Number));
         detail: { source: 'g1', target: 'f3', piece: 'wN' },
       }),
     );
+
+    expect(onResult).toHaveBeenCalledWith('Again', expect.any(Number));
 
     expect(board.getAttribute('data-error-square')).toBe('f3');
     expect(board.getAttribute('data-teaching-arrow')).toBe('e2e4');


### PR DESCRIPTION
## Summary
- expand `App.test.tsx` with keyboard and launcher coverage to exercise all command console entry points
- verify OpeningReviewBoard metadata fallbacks by testing non-string teaching moves, reviewed lines, and promotion reporting
- harden scheduler gateway tests by asserting empty queue payload behaviour and avoiding duplicate websocket variables

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68e70d69c45083259daa0475e60f7598