### PR TITLE
Refine make test orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,66 +1,64 @@
+PROJECT_ROOT := $(shell pwd)
+
+CARGO_LLVM_COV_FLAGS := \
+	--fail-under-functions 100 \
+	--fail-under-lines 100 \
+	--fail-under-regions 100 \
+	--show-missing-lines \
+	-q
+
+.PHONY: test \
+test-steps \
+test-card-store \
+test-chess-training-pgn-import \
+test-scheduler-core \
+test-web-ui \
+test-session-gateway
+
+test: test-steps \
+test-card-store \
+test-chess-training-pgn-import \
+test-scheduler-core \
+test-web-ui \
+test-session-gateway
+
 test-steps:
 	cargo fmt
 	cargo clippy
-	cargo test 
-	cargo llvm-cov \
-		--fail-under-functions 100 \
-	    --fail-under-lines 100 \
-	    --fail-under-regions 100 \
-	    --show-missing-lines \
-	    -q
+	cargo test
+	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
 
-test-steps-js:
-	npm run format
-	npm run lint
-	npm run typecheck
+test-card-store:
+	cd $(PROJECT_ROOT)/crates/card-store && \
+	cargo fmt && \
+	cargo clippy && \
+	cargo test && \
+	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
+
+test-chess-training-pgn-import:
+	cd $(PROJECT_ROOT)/crates/chess-training-pgn-import && \
+	cargo fmt && \
+	cargo clippy && \
+	cargo test && \
+	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
+
+test-scheduler-core:
+	cd $(PROJECT_ROOT)/crates/scheduler-core && \
+	cargo fmt && \
+	cargo clippy && \
+	cargo test && \
+	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
+
+test-web-ui:
+	cd $(PROJECT_ROOT)/web-ui && \
+	npm run format && \
+	npm run lint && \
+	npm run typecheck && \
 	npm run test:coverage
 
-PROJECT_ROOT := $(shell pwd)
-
-test:
-	make test-steps
-
-	cd $(PROJECT_ROOT)/crates/card-store 
-	cargo fmt
-	cargo clippy
-	cargo test 
-	cargo llvm-cov \
-		--fail-under-functions 100 \
-	    --fail-under-lines 100 \
-	    --fail-under-regions 100 \
-	    --show-missing-lines \
-	    -q
-
-	cd $(PROJECT_ROOT)/crates/chess-training-pgn-import
-	cargo fmt
-	cargo clippy
-	cargo test 
-	cargo llvm-cov \
-		--fail-under-functions 100 \
-	    --fail-under-lines 100 \
-	    --fail-under-regions 100 \
-	    --show-missing-lines \
-	    -q
-
-	cd $(PROJECT_ROOT)/crates/scheduler-core
-	cargo fmt
-	cargo clippy
-	cargo test 
-	cargo llvm-cov \
-		--fail-under-functions 100 \
-	    --fail-under-lines 100 \
-	    --fail-under-regions 100 \
-	    --show-missing-lines \
-	    -q
-
-	cd $(PROJECT_ROOT)/web-ui
-	npm run format
-	npm run lint
-	npm run typecheck
-	npm run test:coverage
-
-	cd $(PROJECT_ROOT)/apps/session-gateway
-	npm run format
-	npm run lint
-	npm run typecheck
+test-session-gateway:
+	cd $(PROJECT_ROOT)/apps/session-gateway && \
+	npm run format && \
+	npm run lint && \
+	npm run typecheck && \
 	npm run test:coverage


### PR DESCRIPTION
## Summary
- add reusable phony targets so `make test` invokes every crate and JS project
- ensure per-project recipes stay in their directories by chaining commands with `cd ... &&`
- collect shared coverage flags to reduce duplication in the Makefile

## Testing
- make test *(fails: cargo llvm-cov not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e78d97b3d8832586d8920f50636005

## Summary by Sourcery

Refactor the Makefile to modularize and orchestrate tests across all Rust crates and JS projects by defining reusable phony targets, centralizing coverage flags, and ensuring commands run within their respective directories.

Enhancements:
- Ensure each project’s test commands execute in its own directory using chained cd commands

Build:
- Introduce CARGO_LLVM_COV_FLAGS to collect shared llvm-cov options and reduce duplication
- Define phony targets for per-project test steps (format, lint, test, coverage)
- Update the top-level test target to invoke all sub-project test targets