### PR TITLE
Add PGN import pane and tests for Danish Gambit import

### DIFF
--- a/apps/session-gateway/tests/sessionGateway.test.ts
+++ b/apps/session-gateway/tests/sessionGateway.test.ts
@@ -288,10 +288,13 @@ describe('session gateway', () => {
       card: expect.objectContaining({ card_id: 'c456' }),
       stats: expect.objectContaining({ reviews_today: 1 }),
     });
-    expect((updateMessage as { stats?: unknown })?.stats).toBeTruthy();
+    expect((initialUpdateMessage as { stats?: unknown })?.stats).toBeTruthy();
     await wait();
-    const allUpdateMessages = messages.filter((msg) => (msg as { type: string }).type === 'UPDATE');
-    const statsUpdateMessage = allUpdateMessages.length > 1 ? allUpdateMessages[1] : allUpdateMessages[0];
+    const allUpdateMessages = messages.filter(
+      (msg) => (msg as { type: string }).type === 'UPDATE',
+    );
+    const statsUpdateMessage =
+      allUpdateMessages.length > 1 ? allUpdateMessages[1] : allUpdateMessages[0];
     expect(statsUpdateMessage).toBeTruthy();
     expect((statsUpdateMessage as { stats?: unknown })?.stats).toBeTruthy();
     socket.close();

--- a/web-ui/src/App.css
+++ b/web-ui/src/App.css
@@ -13,6 +13,10 @@
   width: min(960px, 100%);
 }
 
+.dashboard-page {
+  position: relative;
+}
+
 .dashboard {
   background: var(--color-surface);
   border-radius: var(--radius-large);

--- a/web-ui/src/components/PgnImportPane.css
+++ b/web-ui/src/components/PgnImportPane.css
@@ -1,0 +1,167 @@
+.pgn-import-pane {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  transform: translate(-85%, -50%);
+  display: flex;
+  align-items: stretch;
+  transition: transform 0.3s ease;
+  z-index: 100;
+  color: var(--color-text-primary);
+}
+
+.pgn-import-pane-expanded {
+  transform: translate(0, -50%);
+}
+
+.pgn-import-handle {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  border: none;
+  border-radius: 0 var(--radius-large) var(--radius-large) 0;
+  background: rgba(18, 22, 43, 0.75);
+  color: var(--color-text-soft);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  padding: 1rem 0.75rem;
+  cursor: pointer;
+  box-shadow: var(--shadow-elevated);
+  text-transform: uppercase;
+}
+
+.pgn-import-handle:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.4);
+  outline-offset: 4px;
+}
+
+.pgn-import-content {
+  width: 320px;
+  background: var(--color-surface);
+  border-radius: 0 var(--radius-large) var(--radius-large) 0;
+  box-shadow: var(--shadow-elevated);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pgn-import-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.pgn-import-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--color-text-soft);
+  font-size: 0.85rem;
+}
+
+.pgn-import-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pgn-import-option {
+  align-self: flex-start;
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-surface-border);
+  border-radius: var(--radius-compact);
+  color: var(--color-text-primary);
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.pgn-import-option[aria-pressed='true'] {
+  background: rgba(76, 175, 80, 0.2);
+  border-color: rgba(76, 175, 80, 0.4);
+}
+
+.pgn-import-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pgn-import-label {
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+}
+
+.pgn-import-form textarea {
+  min-height: 120px;
+  border-radius: var(--radius-compact);
+  border: 1px solid var(--color-surface-border);
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--color-text-primary);
+  padding: 0.75rem;
+  font-family:
+    'Fira Mono', ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  resize: vertical;
+}
+
+.pgn-import-form textarea:focus {
+  outline: 2px solid rgba(99, 179, 237, 0.6);
+  outline-offset: 2px;
+}
+
+.pgn-import-detection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(56, 178, 172, 0.08);
+  border-radius: var(--radius-compact);
+  border: 1px solid rgba(56, 178, 172, 0.2);
+  padding: 0.75rem;
+}
+
+.pgn-import-preview {
+  font-family:
+    'Fira Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  margin: 0;
+}
+
+.pgn-import-confirm {
+  align-self: flex-start;
+  padding: 0.45rem 0.75rem;
+  border-radius: var(--radius-compact);
+  border: none;
+  cursor: pointer;
+  background: rgba(56, 178, 172, 0.25);
+  color: var(--color-text-primary);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.pgn-import-feedback {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.pgn-import-feedback-success {
+  color: #8be9c3;
+}
+
+.pgn-import-feedback-info {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.pgn-import-feedback-error {
+  color: #ff8a80;
+}
+
+@media (max-width: 960px) {
+  .pgn-import-pane {
+    transform: translate(-92%, -50%);
+  }
+
+  .pgn-import-pane-expanded {
+    transform: translate(-4%, -50%);
+  }
+}

--- a/web-ui/src/components/PgnImportPane.tsx
+++ b/web-ui/src/components/PgnImportPane.tsx
@@ -1,0 +1,243 @@
+import { useRef, useState } from 'react';
+
+import './PgnImportPane.css';
+import type { DetectedOpeningLine, ImportResult } from '../types/repertoire';
+import { formatUnlockDate, UNLOCK_DATE_FALLBACK_LABEL } from '../utils/formatUnlockDate';
+
+type PgnImportPaneProps = {
+  onImportLine: (line: DetectedOpeningLine) => ImportResult;
+};
+
+type FeedbackState =
+  | { kind: 'success' | 'info'; message: string }
+  | { kind: 'error'; message: string }
+  | undefined;
+
+const DANISH_PATTERN = ['e4', 'e5', 'd4', 'exd4', 'c3'] as const;
+
+const sanitizeMoves = (input: string): string[] =>
+  input
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .map((token) => token.trim())
+    .map((token) => token.replace(/^[0-9]+\.\.\./, ''))
+    .map((token) => token.replace(/^[0-9]+\./, ''))
+    .map((token) => token.replace(/[?!+#]/g, ''))
+    .filter((token) => token.length > 0);
+
+const formatMoveSequence = (moves: string[]): string => {
+  const segments: string[] = [];
+  for (let index = 0; index < moves.length; index += 2) {
+    const moveNumber = Math.floor(index / 2) + 1;
+    const whiteMove = moves[index];
+    const blackMove = moves[index + 1];
+    if (whiteMove) {
+      segments.push(`${String(moveNumber)}.${whiteMove}`);
+    }
+    if (blackMove) {
+      segments.push(blackMove);
+    }
+  }
+  return segments.join(' ');
+};
+
+const detectOpening = (input: string): DetectedOpeningLine | undefined => {
+  const moves = sanitizeMoves(input);
+  if (moves.length < DANISH_PATTERN.length) {
+    return undefined;
+  }
+
+  const normalized = moves.map((move) => move.toLowerCase());
+  const isDanish = DANISH_PATTERN.every(
+    (expectedMove, index) => normalized[index] === expectedMove,
+  );
+
+  if (!isDanish) {
+    return undefined;
+  }
+
+  return {
+    opening: 'Danish Gambit',
+    color: 'White',
+    moves,
+    display: formatMoveSequence(moves),
+  } satisfies DetectedOpeningLine;
+};
+
+const buildScheduledMessage = (result: ImportResult): FeedbackState => {
+  const { line, added } = result;
+  const friendlyDate = formatUnlockDate(line.scheduledFor);
+  const lowerColor = line.color.toLowerCase();
+
+  if (friendlyDate === UNLOCK_DATE_FALLBACK_LABEL) {
+    return {
+      kind: added ? 'success' : 'info',
+      message: added
+        ? `Line added to your ${lowerColor} ${line.opening} repertoire.`
+        : `This ${line.opening} line is already part of your ${lowerColor} repertoire.`,
+    };
+  }
+
+  return {
+    kind: added ? 'success' : 'info',
+    message: added
+      ? `Scheduled for ${friendlyDate} in your ${lowerColor} ${line.opening} repertoire.`
+      : `Already scheduled for ${friendlyDate} in your ${lowerColor} ${line.opening} repertoire.`,
+  };
+};
+
+export const PgnImportPane = ({ onImportLine }: PgnImportPaneProps): JSX.Element => {
+  const containerRef = useRef<HTMLElement | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isPasteMode, setIsPasteMode] = useState(false);
+  const [pgnText, setPgnText] = useState('');
+  const [detectedLine, setDetectedLine] = useState<DetectedOpeningLine | undefined>(undefined);
+  const [feedback, setFeedback] = useState<FeedbackState>(undefined);
+
+  const paneContainsFocus = () => {
+    const active = document.activeElement;
+    return Boolean(active && containerRef.current?.contains(active));
+  };
+
+  const handlePointerEnter = () => {
+    setIsExpanded(true);
+  };
+
+  const handlePointerLeave = () => {
+    if (paneContainsFocus()) {
+      return;
+    }
+    setIsExpanded(false);
+  };
+
+  const handleFocusCapture = () => {
+    setIsExpanded(true);
+  };
+
+  const handleBlurCapture = () => {
+    if (!paneContainsFocus()) {
+      setIsExpanded(false);
+    }
+  };
+
+  const handlePasteOption = () => {
+    setIsPasteMode(true);
+    setIsExpanded(true);
+  };
+
+  const handlePgnChange = (value: string) => {
+    setPgnText(value);
+    setFeedback(undefined);
+
+    if (value.trim().length === 0) {
+      setDetectedLine(undefined);
+      setFeedback(undefined);
+      return;
+    }
+
+    const line = detectOpening(value);
+    if (line) {
+      setDetectedLine(line);
+      setFeedback(undefined);
+      return;
+    }
+
+    setDetectedLine(undefined);
+    setFeedback({
+      kind: 'error',
+      message: 'We could not recognize that PGN yet. Try a standard Danish Gambit line.',
+    });
+  };
+
+  const handleConfirm = (line: DetectedOpeningLine) => {
+    const result = onImportLine(line);
+    const message = buildScheduledMessage(result);
+    setFeedback(message);
+
+    if (result.added) {
+      setPgnText('');
+      setDetectedLine(undefined);
+    }
+  };
+
+  return (
+    <aside
+      ref={containerRef}
+      className={`pgn-import-pane${isExpanded ? ' pgn-import-pane-expanded' : ''}`}
+      aria-label="PGN import tools"
+      onPointerLeave={handlePointerLeave}
+      onFocusCapture={handleFocusCapture}
+      onBlurCapture={handleBlurCapture}
+    >
+      <button
+        type="button"
+        className="pgn-import-handle"
+        aria-label="Open PGN import tools"
+        aria-expanded={isExpanded}
+        onPointerEnter={handlePointerEnter}
+        onFocus={handlePointerEnter}
+      >
+        Import PGN
+      </button>
+      <div className="pgn-import-content" aria-hidden={!isExpanded} hidden={!isExpanded}>
+        <header className="pgn-import-header">
+          <h2>Import lines</h2>
+          <p className="pgn-import-subtitle">Grow your repertoire from existing PGNs.</p>
+        </header>
+        <div className="pgn-import-body">
+          <button
+            type="button"
+            className="pgn-import-option"
+            onClick={handlePasteOption}
+            aria-pressed={isPasteMode}
+          >
+            Paste PGN
+          </button>
+
+          {isPasteMode ? (
+            <div className="pgn-import-form" role="region" aria-label="Paste PGN">
+              <label className="pgn-import-label" htmlFor="pgn-import-textarea">
+                Paste moves
+              </label>
+              <textarea
+                id="pgn-import-textarea"
+                value={pgnText}
+                onChange={(event) => {
+                  handlePgnChange(event.target.value);
+                }}
+                placeholder="1.e4 e5 2.d4 exd4 3.c3"
+                aria-label="PGN move input"
+              />
+              {detectedLine ? (
+                <div className="pgn-import-detection" role="status">
+                  <p>
+                    Detected <strong>{detectedLine.opening}</strong> for the{' '}
+                    <strong>{detectedLine.color.toLowerCase()}</strong> pieces.
+                  </p>
+                  <p className="pgn-import-preview">{detectedLine.display}</p>
+                  <button
+                    type="button"
+                    className="pgn-import-confirm"
+                    onClick={() => {
+                      handleConfirm(detectedLine);
+                    }}
+                  >
+                    Add to {detectedLine.opening} ({detectedLine.color})
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+        {feedback ? (
+          <p
+            className={`pgn-import-feedback pgn-import-feedback-${feedback.kind}`}
+            role={feedback.kind === 'error' ? 'alert' : 'status'}
+          >
+            {feedback.message}
+          </p>
+        ) : null}
+      </div>
+    </aside>
+  );
+};

--- a/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
+++ b/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Chess } from 'chess.js';
 
 import type { CardSummary } from '../../types/gateway';

--- a/web-ui/src/components/__tests__/PgnImportPane.test.tsx
+++ b/web-ui/src/components/__tests__/PgnImportPane.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ImportResult } from '../../types/repertoire';
+import { PgnImportPane } from '../PgnImportPane';
+
+describe('PgnImportPane', () => {
+  it('collapses when the pointer leaves and the pane does not retain focus', async () => {
+    render(
+      <PgnImportPane
+        onImportLine={() => ({
+          added: false,
+          line: {
+            id: 'test',
+            opening: 'Danish Gambit',
+            color: 'White',
+            moves: [],
+            display: '',
+            scheduledFor: new Date().toISOString(),
+          },
+        })}
+      />,
+    );
+
+    const handle = screen.getByRole('button', { name: /open pgn import tools/i });
+    expect(handle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.pointerEnter(handle);
+    expect(handle).toHaveAttribute('aria-expanded', 'true');
+
+    const pane = handle.closest('aside');
+    expect(pane).not.toBeNull();
+
+    fireEvent.pointerLeave(pane as Element);
+
+    await waitFor(() => {
+      expect(handle).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  it('displays fallback scheduling messaging when the unlock date cannot be parsed', async () => {
+    const onImportLine = vi.fn(
+      (): ImportResult => ({
+        added: true,
+        line: {
+          id: 'import-test',
+          opening: 'Danish Gambit',
+          color: 'White',
+          moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+          display: '1.e4 e5 2.d4 exd4 3.c3',
+          scheduledFor: 'not-a-valid-date',
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<PgnImportPane onImportLine={onImportLine} />);
+
+    const handle = screen.getByRole('button', { name: /open pgn import tools/i });
+    fireEvent.pointerEnter(handle);
+
+    const pasteOption = await screen.findByRole('button', { name: /paste pgn/i });
+    await user.click(pasteOption);
+
+    const textarea = await screen.findByLabelText(/pgn move input/i);
+    await user.type(textarea, '1.e4 e5 2.d4 exd4 3.c3');
+
+    const confirmButton = await screen.findByRole('button', {
+      name: /add to danish gambit \(white\)/i,
+    });
+    await user.click(confirmButton);
+
+    expect(onImportLine).toHaveBeenCalled();
+
+    const feedback = await screen.findByRole('status');
+    expect(feedback).toHaveTextContent('Line added to your white Danish Gambit repertoire.');
+  });
+
+  it('notifies when the detected line already exists in the repertoire using fallback messaging', async () => {
+    const onImportLine = vi.fn(
+      (): ImportResult => ({
+        added: false,
+        line: {
+          id: 'import-existing',
+          opening: 'Danish Gambit',
+          color: 'White',
+          moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+          display: '1.e4 e5 2.d4 exd4 3.c3',
+          scheduledFor: 'not-a-valid-date',
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<PgnImportPane onImportLine={onImportLine} />);
+
+    const handle = screen.getByRole('button', { name: /open pgn import tools/i });
+    fireEvent.pointerEnter(handle);
+
+    const pasteOption = await screen.findByRole('button', { name: /paste pgn/i });
+    await user.click(pasteOption);
+
+    const textarea = await screen.findByLabelText(/pgn move input/i);
+    await user.type(textarea, '1.e4 e5 2.d4 exd4 3.c3');
+
+    const confirmButton = await screen.findByRole('button', {
+      name: /add to danish gambit \(white\)/i,
+    });
+    await user.click(confirmButton);
+
+    expect(onImportLine).toHaveBeenCalled();
+
+    const feedback = await screen.findByText(
+      'This Danish Gambit line is already part of your white repertoire.',
+    );
+    expect(feedback).toHaveAttribute('role', 'status');
+  });
+});

--- a/web-ui/src/pages/DashboardPage.tsx
+++ b/web-ui/src/pages/DashboardPage.tsx
@@ -1,13 +1,16 @@
 import type { FC } from 'react';
 import { Link } from 'react-router-dom';
 
+import { PgnImportPane } from '../components/PgnImportPane';
 import { ReviewDashboard } from '../components/ReviewDashboard';
 import type { ReviewOverview } from '../services/ReviewPlanner';
+import type { DetectedOpeningLine, ImportResult } from '../types/repertoire';
 
 type DashboardPageProps = {
   overview: ReviewOverview;
   openingPath: string;
   canStartOpening: boolean;
+  onImportLine: (line: DetectedOpeningLine) => ImportResult;
 };
 
 const buildLinkClass = (enabled: boolean): string =>
@@ -17,8 +20,10 @@ export const DashboardPage: FC<DashboardPageProps> = ({
   overview,
   openingPath,
   canStartOpening,
+  onImportLine,
 }) => (
   <main className="app-shell dashboard-page">
+    <PgnImportPane onImportLine={onImportLine} />
     <ReviewDashboard overview={overview} />
     <nav aria-label="Review navigation" className="dashboard-navigation">
       <Link

--- a/web-ui/src/types/repertoire.ts
+++ b/web-ui/src/types/repertoire.ts
@@ -1,0 +1,18 @@
+export type LineColor = 'White' | 'Black';
+
+export type DetectedOpeningLine = {
+  opening: string;
+  color: LineColor;
+  moves: string[];
+  display: string;
+};
+
+export type ScheduledOpeningLine = DetectedOpeningLine & {
+  id: string;
+  scheduledFor: string;
+};
+
+export type ImportResult = {
+  added: boolean;
+  line: ScheduledOpeningLine;
+};


### PR DESCRIPTION
## Summary
- add a PGN import pane to the dashboard that detects Danish Gambit lines and schedules them into the overview
- cover the import workflow, duplicate handling, and fallback messaging with new unit tests
- fix the session gateway websocket test to reference the correct update message after formatting

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e783d168f08325b1c99c07ca4c336c

## Summary by Sourcery

Introduce a PGN import pane for detecting and scheduling Danish Gambit lines in the dashboard, wire up import handling through the App and SessionRoutes, enhance the overview with scheduled imports, and update tests to cover the new import flow and correct a session gateway test.

New Features:
- Add PGN import pane component for pasting PGN and detecting Danish Gambit lines
- Support scheduling imported lines into the review overview as upcoming unlocks
- Integrate the import pane into the dashboard and propagate an import handler through App and SessionRoutes

Bug Fixes:
- Fix session gateway websocket test to reference the correct initial update message and select the proper stats update

Enhancements:
- Define new repertoire types and scheduling utilities for detected opening lines
- Extend the review overview builder to merge scheduled imports into upcoming unlocks

Tests:
- Add unit tests for the PGN import workflow covering detection, scheduling, duplicate handling, and feedback
- Add component tests for the new PgnImportPane