### PR TITLE
Adjust command console overlay visibility and close button placement

### DIFF
--- a/web-ui/src/components/CommandConsole.css
+++ b/web-ui/src/components/CommandConsole.css
@@ -49,19 +49,19 @@
   display: flex;
   justify-content: center;
   align-items: flex-end;
-  padding: 0 1.5rem;
-  background: rgba(3, 6, 20, 0.55);
+  padding: 0 1rem;
+  background: transparent;
   z-index: 1000;
-  animation: command-console-fade-in 200ms ease-out forwards;
+  animation: none;
 }
 
 .command-console-overlay--closing {
-  animation: command-console-fade-out 200ms ease-in forwards;
+  animation: none;
   pointer-events: none;
 }
 
 .command-console {
-  width: min(960px, 100%);
+  width: min(640px, 90%);
   background: rgba(12, 16, 36, 0.94);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-bottom: none;
@@ -82,14 +82,14 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  padding: 1.5rem 1.75rem 1.75rem;
-  min-height: clamp(200px, 25vh, 320px);
+  padding: 1.25rem 1.5rem 1.5rem;
+  min-height: clamp(140px, 18vh, 260px);
 }
 
 .command-console__close {
   position: absolute;
-  top: 1.25rem;
-  right: 1.25rem;
+  top: -1.375rem;
+  right: -1.375rem;
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 50%;
@@ -166,16 +166,12 @@
 }
 
 @media (max-width: 600px) {
-  .command-console-overlay {
-    padding: 0 1rem;
-  }
-
   .command-console__container {
-    padding: 1.25rem 1.25rem 1.5rem;
+    padding: 1rem 1.25rem 1.25rem;
   }
 
   .command-console__body {
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 0.9rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the overlay dimming so the chessboard remains visible when the command console is open
- shrink the command console footprint and move the close button so it hovers over the top-right corner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e793d08a4c8325b6bdf2f387f8f1b0