### PR TITLE
Add must_use to public Rust APIs

### DIFF
--- a/crates/card-store/src/chess_position.rs
+++ b/crates/card-store/src/chess_position.rs
@@ -17,6 +17,7 @@ impl ChessPosition {
     /// Creates a new [`Position`] using a deterministic hash of the FEN as the identifier.
     ///
     /// Returns [`Err`] when the FEN omits or provides an invalid side-to-move field.
+    #[must_use]
     pub fn new(fen: impl Into<String>, ply: u32) -> Result<Self, PositionError> {
         let fen = fen.into();
         let side_to_move = fen

--- a/crates/card-store/src/helpers.rs
+++ b/crates/card-store/src/helpers.rs
@@ -4,6 +4,7 @@ use blake3::Hasher;
 ///
 /// Using a cryptographic hash reduces the risk of accidental collisions when compared
 /// to simple FNV-based hashes while keeping identifier generation deterministic.
+#[must_use]
 pub fn hash64(parts: &[&[u8]]) -> u64 {
     let mut hasher = Hasher::new();
     for part in parts {

--- a/crates/card-store/src/memory/mod.rs
+++ b/crates/card-store/src/memory/mod.rs
@@ -37,6 +37,7 @@ pub struct InMemoryCardStore {
 
 impl InMemoryCardStore {
     /// Construct a new [`InMemoryCardStore`] with the provided [`StorageConfig`].
+    #[must_use]
     pub fn new(config: StorageConfig) -> Self {
         Self {
             _config: config,
@@ -48,6 +49,7 @@ impl InMemoryCardStore {
     }
 
     /// Number of unique positions currently stored. Useful for tests.
+    #[must_use]
     pub fn position_count(&self) -> Result<usize, StoreError> {
         Ok(self.positions_read()?.len())
     }

--- a/crates/card-store/src/model.rs
+++ b/crates/card-store/src/model.rs
@@ -31,6 +31,7 @@ impl EdgeInput {
     ///
     /// The canonical form computes a deterministic edge ID from the parent position and move,
     /// and returns an [`OpeningEdge`] with normalized fields.
+    #[must_use]
     pub fn into_edge(self) -> Edge {
         let id = hash64(&[&self.parent_id.to_be_bytes(), self.move_uci.as_bytes()]);
         Edge {
@@ -66,6 +67,7 @@ pub struct StoredCardState {
 
 impl StoredCardState {
     /// Creates a new [`StoredCardState`] with sensible defaults.
+    #[must_use]
     pub fn new(due_on: NaiveDate, interval: NonZeroU8, ease_factor: f32) -> Self {
         Self {
             due_on,
@@ -101,11 +103,13 @@ pub type UnlockRecord = GenericUnlockRecord<String, UnlockDetail>;
 pub type UnlockRecord = GenericUnlockRecord<String, UnlockDetail>;
 
 /// Deterministically compute a card identifier for an opening edge.
+#[must_use]
 pub fn card_id_for_opening(owner_id: &str, edge_id: u64) -> u64 {
     hash64(&[owner_id.as_bytes(), &edge_id.to_be_bytes()])
 }
 
 /// Deterministically compute a card identifier for a tactic.
+#[must_use]
 pub fn card_id_for_tactic(owner_id: &str, tactic_id: u64) -> u64 {
     hash64(&[owner_id.as_bytes(), &tactic_id.to_be_bytes()])
 }

--- a/crates/chess-training-pgn-import/src/config.rs
+++ b/crates/chess-training-pgn-import/src/config.rs
@@ -195,6 +195,7 @@ impl CliArgs {
     }
 
     /// Attempts to parse CLI arguments using the custom command definition.
+    #[must_use]
     pub fn try_parse_from<I, T>(iterator: I) -> ClapResult<Self>
     where
         I: IntoIterator<Item = T>,
@@ -206,6 +207,7 @@ impl CliArgs {
     }
 
     /// Converts the parsed CLI arguments into the runtime configuration and remaining inputs.
+    #[must_use]
     pub fn into_ingest_config(self) -> ConfigResult<(IngestConfig, Vec<PathBuf>)> {
         let CliArgs {
             inputs,

--- a/crates/chess-training-pgn-import/src/errors.rs
+++ b/crates/chess-training-pgn-import/src/errors.rs
@@ -12,11 +12,13 @@ pub struct IoError {
 
 impl IoError {
     /// Returns the path that failed to load.
+    #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
     }
 
     /// Returns the underlying IO error that caused the failure.
+    #[must_use]
     pub fn io_error(&self) -> &io::Error {
         &self.source
     }
@@ -48,11 +50,13 @@ pub struct ParseError {
 
 impl ParseError {
     /// Returns the path of the configuration file that failed to parse.
+    #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
     }
 
     /// Returns the underlying TOML parse error.
+    #[must_use]
     pub fn toml_error(&self) -> &toml::de::Error {
         &self.source
     }

--- a/crates/chess-training-pgn-import/src/importer.rs
+++ b/crates/chess-training-pgn-import/src/importer.rs
@@ -93,6 +93,7 @@ pub struct Importer<S: Storage> {
 }
 
 impl<S: Storage> Importer<S> {
+    #[must_use]
     pub fn new(config: IngestConfig, store: S) -> Self {
         Self {
             config,
@@ -101,6 +102,7 @@ impl<S: Storage> Importer<S> {
         }
     }
 
+    #[must_use]
     pub fn ingest_pgn_str(
         &mut self,
         owner: &str,
@@ -122,12 +124,14 @@ impl<S: Storage> Importer<S> {
         Ok(())
     }
 
+    #[must_use]
     pub fn finalize(self) -> (S, ImportMetrics) {
         (self.store, self.metrics)
     }
 }
 
 impl Importer<ImportInMemoryStore> {
+    #[must_use]
     pub fn new_in_memory(config: IngestConfig) -> Self {
         Self::new(config, ImportInMemoryStore::default())
     }

--- a/crates/chess-training-pgn-import/src/model.rs
+++ b/crates/chess-training-pgn-import/src/model.rs
@@ -16,6 +16,7 @@ pub struct Position {
 }
 
 impl Position {
+    #[must_use]
     pub fn new(fen: &str, side_to_move: char, ply: u32) -> Self {
         let id = hash_with_seed(HASH_NAMESPACE, SCHEMA_VERSION, &fen);
         Self {
@@ -36,6 +37,7 @@ pub struct OpeningEdgeRecord {
 
 impl OpeningEdgeRecord {
     #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn new(
         parent_id: u64,
         move_uci: &str,
@@ -57,6 +59,7 @@ pub struct RepertoireEdge {
 }
 
 impl RepertoireEdge {
+    #[must_use]
     pub fn new(owner: &str, repertoire_key: &str, edge_id: u64) -> Self {
         Self {
             owner: owner.to_string(),
@@ -76,6 +79,7 @@ pub struct Tactic {
 }
 
 impl Tactic {
+    #[must_use]
     pub fn new(
         fen: &str,
         pv_uci: Vec<String>,

--- a/crates/chess-training-pgn-import/src/storage.rs
+++ b/crates/chess-training-pgn-import/src/storage.rs
@@ -48,22 +48,27 @@ impl Storage for ImportInMemoryStore {
 }
 
 impl ImportInMemoryStore {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    #[must_use]
     pub fn positions(&self) -> Vec<Position> {
         self.positions.values().cloned().collect()
     }
 
+    #[must_use]
     pub fn edges(&self) -> Vec<OpeningEdgeRecord> {
         self.edges.values().cloned().collect()
     }
 
+    #[must_use]
     pub fn tactics(&self) -> Vec<Tactic> {
         self.tactics.values().cloned().collect()
     }
 
+    #[must_use]
     pub fn repertoire_edges(&self) -> Vec<RepertoireEdge> {
         self.repertoire_edges
             .iter()

--- a/crates/review-domain/src/card_kind.rs
+++ b/crates/review-domain/src/card_kind.rs
@@ -11,6 +11,7 @@ pub enum CardKind<Opening, Tactic> {
 
 impl<Opening, Tactic> CardKind<Opening, Tactic> {
     /// Maps the opening payload to a different type while leaving the tactic payload untouched.
+    #[must_use]
     pub fn map_opening<O2>(self, mapper: impl FnOnce(Opening) -> O2) -> CardKind<O2, Tactic> {
         match self {
             CardKind::Opening(opening) => CardKind::Opening(mapper(opening)),
@@ -19,6 +20,7 @@ impl<Opening, Tactic> CardKind<Opening, Tactic> {
     }
 
     /// Maps the tactic payload to a different type while leaving the opening payload untouched.
+    #[must_use]
     pub fn map_tactic<T2>(self, mapper: impl FnOnce(Tactic) -> T2) -> CardKind<Opening, T2> {
         match self {
             CardKind::Opening(opening) => CardKind::Opening(opening),
@@ -27,6 +29,7 @@ impl<Opening, Tactic> CardKind<Opening, Tactic> {
     }
 
     /// Returns references to the payload without moving the value.
+    #[must_use]
     pub fn as_ref(&self) -> CardKind<&Opening, &Tactic> {
         match self {
             CardKind::Opening(opening) => CardKind::Opening(opening),

--- a/crates/review-domain/src/opening.rs
+++ b/crates/review-domain/src/opening.rs
@@ -9,6 +9,7 @@ pub struct OpeningCard {
 
 impl OpeningCard {
     /// Creates a new `OpeningCard` payload.
+    #[must_use]
     pub fn new(edge_id: u64) -> Self {
         Self { edge_id }
     }
@@ -32,6 +33,7 @@ pub struct OpeningEdge {
 
 impl OpeningEdge {
     /// Builds a new opening edge.
+    #[must_use]
     pub fn new(
         id: u64,
         parent_id: u64,

--- a/crates/review-domain/src/study_stage.rs
+++ b/crates/review-domain/src/study_stage.rs
@@ -15,26 +15,31 @@ pub enum StudyStage {
 
 impl StudyStage {
     /// Returns true if the card is in the New stage.
+    #[must_use]
     pub fn is_new(self) -> bool {
         matches!(self, StudyStage::New)
     }
 
     /// Returns true if the card is in the Learning stage.
+    #[must_use]
     pub fn is_learning(self) -> bool {
         matches!(self, StudyStage::Learning)
     }
 
     /// Returns true if the card is in the Review stage.
+    #[must_use]
     pub fn is_review(self) -> bool {
         matches!(self, StudyStage::Review)
     }
 
     /// Returns true if the card is in the Relearning stage.
+    #[must_use]
     pub fn is_relearning(self) -> bool {
         matches!(self, StudyStage::Relearning)
     }
 
     /// Returns true if the card is in any of the active stages (Learning, Review, Relearning).
+    #[must_use]
     pub fn is_active(self) -> bool {
         matches!(
             self,
@@ -43,6 +48,7 @@ impl StudyStage {
     }
 
     /// Converts a character to a `StudyStage`.
+    #[must_use]
     pub fn from_char(c: char) -> Option<Self> {
         match c {
             'N' | 'n' => Some(StudyStage::New),

--- a/crates/review-domain/src/tactic.rs
+++ b/crates/review-domain/src/tactic.rs
@@ -9,6 +9,7 @@ pub struct TacticCard {
 
 impl TacticCard {
     /// Creates a new `TacticCard` payload.
+    #[must_use]
     pub fn new(tactic_id: u64) -> Self {
         Self { tactic_id }
     }

--- a/crates/review-domain/src/unlock.rs
+++ b/crates/review-domain/src/unlock.rs
@@ -15,6 +15,7 @@ pub struct UnlockRecord<Owner, Detail> {
 
 impl<Owner, Detail> UnlockRecord<Owner, Detail> {
     /// Maps the domain-specific payload to a different type while preserving metadata.
+    #[must_use]
     pub fn map_detail<D2>(self, mapper: impl FnOnce(Detail) -> D2) -> UnlockRecord<Owner, D2> {
         UnlockRecord {
             owner_id: self.owner_id,
@@ -33,6 +34,7 @@ pub struct UnlockDetail {
 
 impl UnlockDetail {
     /// Creates a new unlock detail payload.
+    #[must_use]
     pub fn new(edge_id: u64) -> Self {
         Self { edge_id }
     }

--- a/crates/scheduler-core/src/domain/card.rs
+++ b/crates/scheduler-core/src/domain/card.rs
@@ -11,6 +11,7 @@ use super::Sm2State;
 pub type Card = GenericCard<Uuid, Uuid, CardKind, Sm2State>;
 
 /// Constructs a new scheduler card with SM-2 defaults.
+#[must_use]
 pub fn new_card(
     owner_id: Uuid,
     kind: CardKind,

--- a/crates/scheduler-core/src/domain/card_kind.rs
+++ b/crates/scheduler-core/src/domain/card_kind.rs
@@ -7,6 +7,7 @@ pub struct SchedulerOpeningCard {
 }
 
 impl SchedulerOpeningCard {
+    #[must_use]
     pub fn new(parent_prefix: impl Into<String>) -> Self {
         Self {
             parent_prefix: parent_prefix.into(),
@@ -19,6 +20,7 @@ impl SchedulerOpeningCard {
 pub struct SchedulerTacticCard;
 
 impl SchedulerTacticCard {
+    #[must_use]
     pub fn new() -> Self {
         Self
     }

--- a/crates/scheduler-core/src/domain/sm2_state.rs
+++ b/crates/scheduler-core/src/domain/sm2_state.rs
@@ -1,5 +1,5 @@
-use chrono::NaiveDate;
 use super::CardState;
+use chrono::NaiveDate;
 
 /// Mutable SM-2 scheduling data tracked for a card.
 #[derive(Debug, Clone, PartialEq)]
@@ -20,6 +20,7 @@ pub struct Sm2State {
 
 impl Sm2State {
     /// Constructs a new SM-2 state for a freshly created card.
+    #[must_use]
     pub fn new(stage: CardState, today: NaiveDate, initial_ease: f32) -> Self {
         Self {
             stage,

--- a/crates/scheduler-core/src/queue.rs
+++ b/crates/scheduler-core/src/queue.rs
@@ -9,6 +9,7 @@ use crate::config::SchedulerConfig;
 use crate::domain::{Card, CardKind, CardState, SchedulerUnlockDetail, UnlockRecord};
 use crate::store::CardStore;
 
+#[must_use]
 pub fn build_queue_for_day<S: CardStore>(
     store: &mut S,
     config: &SchedulerConfig,
@@ -109,7 +110,7 @@ fn extract_prefix(card: &Card) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{new_card, CardKind, SchedulerOpeningCard, SchedulerUnlockDetail};
+    use crate::domain::{CardKind, SchedulerOpeningCard, SchedulerUnlockDetail, new_card};
     use crate::store::InMemoryStore;
 
     fn naive_date(year: i32, month: u32, day: u32) -> NaiveDate {

--- a/crates/scheduler-core/src/scheduler.rs
+++ b/crates/scheduler-core/src/scheduler.rs
@@ -17,10 +17,12 @@ pub struct Scheduler<S: CardStore> {
 }
 
 impl<S: CardStore> Scheduler<S> {
+    #[must_use]
     pub fn new(store: S, config: SchedulerConfig) -> Self {
         Self { store, config }
     }
 
+    #[must_use]
     pub fn review(
         &mut self,
         card_id: Uuid,
@@ -41,10 +43,12 @@ impl<S: CardStore> Scheduler<S> {
         })
     }
 
+    #[must_use]
     pub fn build_queue(&mut self, owner_id: Uuid, today: NaiveDate) -> Vec<Card> {
         build_queue_for_day(&mut self.store, &self.config, owner_id, today)
     }
 
+    #[must_use]
     pub fn into_store(self) -> S {
         self.store
     }
@@ -53,7 +57,7 @@ impl<S: CardStore> Scheduler<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{new_card, CardKind, CardState, SchedulerTacticCard};
+    use crate::domain::{CardKind, CardState, SchedulerTacticCard, new_card};
     use crate::store::InMemoryStore;
 
     fn naive_date(year: i32, month: u32, day: u32) -> NaiveDate {

--- a/crates/scheduler-core/src/store.rs
+++ b/crates/scheduler-core/src/store.rs
@@ -23,6 +23,7 @@ pub struct InMemoryStore {
 }
 
 impl InMemoryStore {
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -87,7 +88,7 @@ impl CardStore for InMemoryStore {
 mod tests {
     use super::*;
     use crate::config::SchedulerConfig;
-    use crate::domain::{new_card, SchedulerTacticCard, SchedulerUnlockDetail};
+    use crate::domain::{SchedulerTacticCard, SchedulerUnlockDetail, new_card};
     use chrono::NaiveDate;
 
     fn naive_date(year: i32, month: u32, day: u32) -> NaiveDate {


### PR DESCRIPTION
## Summary
- add `#[must_use]` to public constructors, helpers, and accessors across the workspace
- ensure scheduler and importer APIs warn when their results are ignored

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e7984382d48325bedcdb19547dd6e7