### PR TITLE
Fix clippy lints in PGN import configuration

### DIFF
--- a/crates/chess-training-pgn-import/src/config.rs
+++ b/crates/chess-training-pgn-import/src/config.rs
@@ -36,6 +36,7 @@ pub use crate::errors::ConfigError;
 use crate::errors::{IoError, ParseError};
 
 /// Runtime configuration for the PGN ingest pipeline.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IngestConfig {
     pub tactic_from_fen: bool,
@@ -195,7 +196,6 @@ impl CliArgs {
     }
 
     /// Attempts to parse CLI arguments using the custom command definition.
-    #[must_use]
     pub fn try_parse_from<I, T>(iterator: I) -> ClapResult<Self>
     where
         I: IntoIterator<Item = T>,
@@ -207,7 +207,6 @@ impl CliArgs {
     }
 
     /// Converts the parsed CLI arguments into the runtime configuration and remaining inputs.
-    #[must_use]
     pub fn into_ingest_config(self) -> ConfigResult<(IngestConfig, Vec<PathBuf>)> {
         let CliArgs {
             inputs,

--- a/crates/chess-training-pgn-import/src/importer.rs
+++ b/crates/chess-training-pgn-import/src/importer.rs
@@ -102,7 +102,6 @@ impl<S: Storage> Importer<S> {
         }
     }
 
-    #[must_use]
     pub fn ingest_pgn_str(
         &mut self,
         owner: &str,


### PR DESCRIPTION
## Summary
- silence clippy's excessive bool lint on `IngestConfig`
- drop redundant `#[must_use]` attributes on CLI parsing helpers that already return `Result`
- remove the unnecessary `#[must_use]` attribute from `Importer::ingest_pgn_str`

## Testing
- cargo clippy -p chess-training-pgn-import -- -D warnings
- make test (fails: existing coverage thresholds in card-store)


------
https://chatgpt.com/codex/tasks/task_e_68e7a2405bd48325ac7321b0e69716e0