### PR TITLE
Exclude built artifacts from session-gateway coverage

### DIFF
--- a/apps/session-gateway/vitest.config.ts
+++ b/apps/session-gateway/vitest.config.ts
@@ -5,7 +5,13 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       provider: 'v8',
-      exclude: ['src/index.ts', 'src/types.ts', 'eslint.config.js', 'vitest.config.ts'],
+      exclude: [
+        'src/index.ts',
+        'src/types.ts',
+        'eslint.config.js',
+        'vitest.config.ts',
+        'dist/**',
+      ],
       thresholds: {
         lines: 99,
         functions: 94,


### PR DESCRIPTION
## Summary
- exclude the generated `dist` directory from Vitest coverage accounting so the session-gateway suite only reports on TypeScript sources

## Testing
- npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text --run
- make test *(fails: repository-wide coverage thresholds in crates/card-store and crates/review-domain are below the configured 100% requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68e7aac697448325b960fe691c6ee80c

## Summary by Sourcery

Tests:
- Add 'dist/**' to the coverage exclusion list in the session-gateway Vitest config