### PR TITLE
Fix scheduler-core clippy pedantic warnings

### DIFF
--- a/crates/scheduler-core/examples/quickstart.rs
+++ b/crates/scheduler-core/examples/quickstart.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Add some sample cards to the store
     let owner_id = Uuid::new_v4();
-    let today = NaiveDate::from_ymd_opt(2025, 1, 15).unwrap();
+    let today = NaiveDate::from_ymd_opt(2025, 1, 15).expect("valid example date");
 
     // Create a new opening card
     let card1 = new_card(

--- a/crates/scheduler-core/src/config.rs
+++ b/crates/scheduler-core/src/config.rs
@@ -23,12 +23,16 @@ impl Default for SchedulerConfig {
 mod tests {
     use super::*;
 
+    fn approx_eq(lhs: f32, rhs: f32) -> bool {
+        (lhs - rhs).abs() <= f32::EPSILON
+    }
+
     #[test]
     fn default_configuration_matches_expected_values() {
         let config = SchedulerConfig::default();
-        assert!((config.initial_ease_factor - 2.5).abs() <= f32::EPSILON);
-        assert!((config.ease_minimum - 1.3).abs() <= f32::EPSILON);
-        assert!((config.ease_maximum - 2.8).abs() <= f32::EPSILON);
+        assert!(approx_eq(config.initial_ease_factor, 2.5));
+        assert!(approx_eq(config.ease_minimum, 1.3));
+        assert!(approx_eq(config.ease_maximum, 2.8));
         assert_eq!(config.learning_steps_minutes, vec![1, 10]);
     }
 }

--- a/crates/scheduler-core/src/domain/card.rs
+++ b/crates/scheduler-core/src/domain/card.rs
@@ -34,7 +34,7 @@ mod tests {
     fn common_setup() -> (Uuid, CardKind, NaiveDate, SchedulerConfig) {
         let owner_id = Uuid::new_v4();
         let kind = CardKind::Opening(SchedulerOpeningCard::new("e4"));
-        let today = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+        let today = NaiveDate::from_ymd_opt(2024, 6, 1).expect("valid fixture date");
         let config = SchedulerConfig {
             initial_ease_factor: 2.5,
             ease_minimum: 1.3,
@@ -63,7 +63,7 @@ mod tests {
         let card = new_card(
             owner_id,
             CardKind::Opening(SchedulerOpeningCard::new("e4")),
-            NaiveDate::from_ymd_opt(2024, 6, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 6, 1).expect("valid fixture date"),
             &SchedulerConfig::default(),
         );
         assert_eq!(card.owner_id, owner_id);
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn card_struct_should_allow_setting_due_to_past_date() {
         let mut card = common_card();
-        let past_date = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let past_date = NaiveDate::from_ymd_opt(2000, 1, 1).expect("valid past date");
         card.state.due = past_date;
         assert_eq!(card.state.due, past_date);
     }
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn card_struct_should_allow_setting_due_to_future_date() {
         let mut card = common_card();
-        let future_date = NaiveDate::from_ymd_opt(2100, 1, 1).unwrap();
+        let future_date = NaiveDate::from_ymd_opt(2100, 1, 1).expect("valid future date");
         card.state.due = future_date;
         assert_eq!(card.state.due, future_date);
     }

--- a/crates/scheduler-core/src/domain/mod.rs
+++ b/crates/scheduler-core/src/domain/mod.rs
@@ -44,7 +44,8 @@ mod tests {
     fn card_new_initializes_expected_defaults() {
         let config = SchedulerConfig::default();
         let owner = Uuid::new_v4();
-        let today = chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap();
+        let today = chrono::NaiveDate::from_ymd_opt(2023, 1, 1)
+            .expect("1 January 2023 should be representable");
         let card = new_card(
             owner,
             CardKind::Tactic(SchedulerTacticCard::new()),

--- a/crates/scheduler-core/tests/scheduler_sm2.rs
+++ b/crates/scheduler-core/tests/scheduler_sm2.rs
@@ -67,7 +67,10 @@ fn sm2_good_review_promotes_new_card() {
 
     assert_eq!(outcome.card.state.stage, CardState::Review);
     assert_eq!(outcome.card.state.interval_days, 1);
-    assert_eq!(outcome.card.state.due, today.succ_opt().unwrap());
+    assert_eq!(
+        outcome.card.state.due,
+        today.succ_opt().expect("successor date should exist")
+    );
     assert_eq!(outcome.card.state.reviews, 1);
 
     let store = scheduler.into_store();
@@ -106,7 +109,10 @@ fn sm2_again_resets_interval_and_ease() {
 
     assert_eq!(outcome.card.state.stage, CardState::Relearning);
     assert_eq!(outcome.card.state.interval_days, 1);
-    assert_eq!(outcome.card.state.due, today.succ_opt().unwrap());
+    assert_eq!(
+        outcome.card.state.due,
+        today.succ_opt().expect("successor date should exist")
+    );
     assert_eq!(outcome.card.state.lapses, 1);
     assert!(outcome.card.state.ease_factor >= config.ease_minimum);
     assert!(outcome.card.state.ease_factor < 2.4);


### PR DESCRIPTION
## Summary
- add a small helper for approximate float comparisons in the scheduler config tests
- replace `unwrap()` calls with `expect()` across scheduler-core tests and example code to satisfy pedantic clippy
- ensure SM-2 integration tests unwrap successor dates with explicit expectations

## Testing
- cargo clippy -p scheduler-core --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic
- cargo test -p scheduler-core

------
https://chatgpt.com/codex/tasks/task_e_68e7f93bc174832599d09acca9ee067d