### PR TITLE
Fix command console close button clipping

### DIFF
--- a/web-ui/src/components/CommandConsole.css
+++ b/web-ui/src/components/CommandConsole.css
@@ -68,7 +68,7 @@
   border-radius: var(--radius-large) var(--radius-large) 0 0;
   box-shadow: 0 -24px 48px rgba(3, 6, 20, 0.55);
   color: var(--color-text-primary);
-  overflow: hidden;
+  overflow: visible;
   transform: translateY(100%);
   animation: command-console-slide-up 240ms ease-out forwards;
   position: relative;


### PR DESCRIPTION
## Summary
- allow the command console container to overflow so the floating close button remains fully visible

## Testing
- make test *(fails: existing coverage thresholds in `card-store` are below the enforced 100% requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68e7fde55ebc8325bed8b83452c42013