### PR TITLE
Derive Copy for review domain cards

### DIFF
--- a/crates/review-domain/src/opening.rs
+++ b/crates/review-domain/src/opening.rs
@@ -1,7 +1,7 @@
 //! Shared opening-specific data structures.
 
 /// Payload carried by opening review cards.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OpeningCard {
     /// Identifier of the reviewed opening edge.
     pub edge_id: u64,
@@ -59,6 +59,13 @@ mod tests {
     fn opening_card_constructor_sets_fields() {
         let card = OpeningCard::new(42);
         assert_eq!(card.edge_id, 42);
+    }
+
+    #[test]
+    fn opening_card_is_copy() {
+        fn assert_impl_copy<T: Copy>() {}
+
+        assert_impl_copy::<OpeningCard>();
     }
 
     #[test]

--- a/crates/review-domain/src/tactic.rs
+++ b/crates/review-domain/src/tactic.rs
@@ -1,7 +1,7 @@
 //! Shared tactic-specific data structures.
 
 /// Payload carried by tactic review cards.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TacticCard {
     /// Identifier of the reviewed tactic.
     pub tactic_id: u64,
@@ -12,5 +12,23 @@ impl TacticCard {
     #[must_use]
     pub fn new(tactic_id: u64) -> Self {
         Self { tactic_id }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tactic_card_constructor_sets_fields() {
+        let card = TacticCard::new(99);
+        assert_eq!(card.tactic_id, 99);
+    }
+
+    #[test]
+    fn tactic_card_is_copy() {
+        fn assert_impl_copy<T: Copy>() {}
+
+        assert_impl_copy::<TacticCard>();
     }
 }


### PR DESCRIPTION
## Summary
- derive the `Copy` marker for the simple `OpeningCard` and `TacticCard` payload structs
- add focused unit tests that assert both card payloads satisfy the `Copy` contract

## Testing
- cargo test --workspace
- make test *(fails: card-store coverage is below the enforced 100% threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68e7fe26e4b08325af95ec5cec2eadc9