### PR TITLE
Simplify opening card validation matches

### DIFF
--- a/crates/card-store/src/memory/cards.rs
+++ b/crates/card-store/src/memory/cards.rs
@@ -4,6 +4,7 @@ use chrono::NaiveDate;
 
 use crate::model::{Card, CardKind, Edge, OpeningCard, ReviewRequest, StoredCardState};
 use crate::store::StoreError;
+use review_domain::CardKind as GenericCardKind;
 
 pub(super) fn store_opening_card(
     cards: &mut HashMap<u64, Card>,
@@ -55,8 +56,8 @@ fn validate_existing_opening_card(
 ) -> Result<(), StoreError> {
     if card.owner_id == owner_id
         && matches!(
-            card.kind,
-            CardKind::Opening(ref opening) if opening.edge_id == edge.id
+            card.kind.as_ref(),
+            GenericCardKind::Opening(opening) if opening.edge_id == edge.id
         )
     {
         Ok(())

--- a/crates/chess-training-pgn-import/src/storage.rs
+++ b/crates/chess-training-pgn-import/src/storage.rs
@@ -65,10 +65,11 @@ impl Storage for ImportInMemoryStore {
     }
 
     fn upsert_repertoire_edge(&mut self, record: RepertoireEdge) -> UpsertOutcome {
-        UpsertOutcome::from_bool(
-            self.repertoire_edges
-                .insert((record.owner, record.repertoire_key, record.edge_id)),
-        )
+        UpsertOutcome::from_bool(self.repertoire_edges.insert((
+            record.owner,
+            record.repertoire_key,
+            record.edge_id,
+        )))
     }
 
     fn upsert_tactic(&mut self, tactic: Tactic) -> UpsertOutcome {
@@ -143,9 +144,11 @@ mod tests {
         let child = sample_position(1);
         let edge = OpeningEdgeRecord::new(parent.id, "e2e4", "e4", child.id, None);
         assert!(store.upsert_edge(edge.clone()).is_inserted());
-        assert!(store
-            .upsert_repertoire_edge(RepertoireEdge::new("owner", "rep", edge.edge.id))
-            .is_inserted());
+        assert!(
+            store
+                .upsert_repertoire_edge(RepertoireEdge::new("owner", "rep", edge.edge.id))
+                .is_inserted()
+        );
 
         let records = store.repertoire_edges();
         assert_eq!(records.len(), 1);


### PR DESCRIPTION
## Summary
- update the card-store opening card validator to use `as_ref()` so it no longer relies on the `ref` pattern inside `matches!`
- pull in the generic `CardKind` alias needed for the new pattern
- accept the workspace formatting that `cargo fmt` applied to the PGN importer storage module during testing

## Testing
- make test *(fails: `cargo llvm-cov` reports <100% coverage for card-store)*

------
https://chatgpt.com/codex/tasks/task_e_68e7fe17fa608325ad6adffb52380f43