### PR TITLE
Remove unused command console fade animations

### DIFF
--- a/web-ui/src/components/CommandConsole.css
+++ b/web-ui/src/components/CommandConsole.css
@@ -212,20 +212,3 @@
   }
 }
 
-@keyframes command-console-fade-in {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes command-console-fade-out {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}


### PR DESCRIPTION
## Summary
- remove the unused command console fade keyframe animations since the overlay now disables animations

## Testing
- make test *(fails: cargo llvm-cov enforces 100% coverage for card-store crate)*

------
https://chatgpt.com/codex/tasks/task_e_68e7fdf12c0c83258c382d13f4f9ca09