### PR TITLE
Fix card_kind tests to satisfy clippy

### DIFF
--- a/crates/review-domain/src/card_kind.rs
+++ b/crates/review-domain/src/card_kind.rs
@@ -44,29 +44,29 @@ mod tests {
 
     #[test]
     fn map_opening_transforms_opening_variant() {
-        let card: CardKind<String, ()> = CardKind::Opening("line".to_string());
-        let mapped: CardKind<usize, _> = card.map_opening(|opening| opening.len());
+        let card: CardKind<&str, ()> = CardKind::Opening("line");
+        let mapped: CardKind<usize, _> = card.map_opening(str::len);
         assert!(matches!(mapped, CardKind::Opening(4)));
     }
 
     #[test]
     fn map_opening_leaves_tactic_variant_untouched() {
         let card: CardKind<&str, _> = CardKind::Tactic("fork");
-        let mapped = card.map_opening(|opening| opening.len());
+        let mapped = card.map_opening(str::len);
         assert!(matches!(mapped, CardKind::Tactic("fork")));
     }
 
     #[test]
     fn map_tactic_transforms_tactic_variant() {
-        let card: CardKind<(), String> = CardKind::Tactic("pin".to_string());
-        let mapped: CardKind<(), usize> = card.map_tactic(|tactic| tactic.len());
+        let card: CardKind<(), &str> = CardKind::Tactic("pin");
+        let mapped: CardKind<(), usize> = card.map_tactic(str::len);
         assert!(matches!(mapped, CardKind::Tactic(3)));
     }
 
     #[test]
     fn map_tactic_leaves_opening_variant_untouched() {
         let card: CardKind<_, &str> = CardKind::Opening("Najdorf");
-        let mapped = card.map_tactic(|tactic| tactic.len());
+        let mapped = card.map_tactic(str::len);
         assert!(matches!(mapped, CardKind::Opening("Najdorf")));
     }
 


### PR DESCRIPTION
## Summary
- use shared `str::len` function in `CardKind` tests to avoid redundant closures
- adjust test data to borrow `&str` instead of owning `String`

## Testing
- cargo clippy -p review-domain --all-targets --all-features -- -D clippy::all -D clippy::pedantic

------
https://chatgpt.com/codex/tasks/task_e_68e80aee1c0c8325b666b9b69b52352d