### PR TITLE
Fix CI coverage command for cargo-llvm-cov compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
             --all-features \
             --fail-under-lines 100 \
             --fail-under-functions 100 \
-            --fail-under-branches 100 \
             --fail-under-regions 100 \
             --show-missing-lines \
             --lcov --output-path target/llvm-cov/${{ matrix.crate }}.lcov


### PR DESCRIPTION
## Summary
- remove the unsupported `--fail-under-branches` flag from the cargo-llvm-cov CI step so coverage runs do not fail

## Testing
- make test *(fails: cargo llvm-cov is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e80b3b74988325ab416b65fcda875b