### PR TITLE
Fix clippy double must_use lint in storage

### DIFF
--- a/crates/chess-training-pgn-import/src/storage.rs
+++ b/crates/chess-training-pgn-import/src/storage.rs
@@ -36,7 +36,6 @@ impl UpsertOutcome {
         matches!(self, Self::Inserted)
     }
 
-    #[must_use]
     pub const fn from_bool(inserted: bool) -> Self {
         if inserted {
             Self::Inserted


### PR DESCRIPTION
## Summary
- remove the redundant `#[must_use]` attribute from `UpsertOutcome::from_bool`

## Testing
- cargo clippy -p chess-training-pgn-import

------
https://chatgpt.com/codex/tasks/task_e_68e80b0fd41c8325a443508a317d271e