### PR TITLE
Ensure cargo llvm cov output directories exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test-steps:
 	cargo fmt
 	cargo clippy
 	cargo test
+	mkdir -p target/llvm-cov
 	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
 
 test-card-store:
@@ -33,6 +34,7 @@ test-card-store:
 	cargo fmt && \
 	cargo clippy && \
 	cargo test && \
+	mkdir -p target/llvm-cov && \
 	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
 
 test-chess-training-pgn-import:
@@ -40,6 +42,7 @@ test-chess-training-pgn-import:
 	cargo fmt && \
 	cargo clippy && \
 	cargo test && \
+	mkdir -p target/llvm-cov && \
 	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
 
 test-scheduler-core:
@@ -47,6 +50,7 @@ test-scheduler-core:
 	cargo fmt && \
 	cargo clippy && \
 	cargo test && \
+	mkdir -p target/llvm-cov && \
 	cargo llvm-cov $(CARGO_LLVM_COV_FLAGS)
 
 test-web-ui:


### PR DESCRIPTION
## Summary
- create the target/llvm-cov directory in each Rust package before running cargo llvm-cov so the coverage report can be written

## Testing
- make test-steps

------
https://chatgpt.com/codex/tasks/task_e_68e8125ca53083258414272d059da6b6