### PR TITLE
Fix formatting for mapped_opening assignment

### DIFF
--- a/crates/card-store/src/model.rs
+++ b/crates/card-store/src/model.rs
@@ -127,8 +127,8 @@ mod tests {
     #[test]
     fn card_kind_helpers_cover_review_domain_types() {
         let opening = OpeningCard::new(7);
-        let mapped_opening = CardKind::Opening(opening)
-            .map_opening(|card| OpeningCard::new(card.edge_id + 1));
+        let mapped_opening =
+            CardKind::Opening(opening).map_opening(|card| OpeningCard::new(card.edge_id + 1));
         assert!(matches!(
             mapped_opening,
             CardKind::Opening(card) if card.edge_id == 8


### PR DESCRIPTION
## Summary
- restore the multi-line formatting of the `mapped_opening` assignment in the card-store tests to match project style

## Testing
- make test *(fails: `cargo llvm-cov` subcommand not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e81227e85083258538c200b267e424