### PR TITLE
Ensure CI coverage step prepares output directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         run: cargo test -p ${{ matrix.crate }} --release --all-features -- --nocapture
       - name: Enforce coverage (${{ matrix.crate }})
         run: |
+          mkdir -p target/llvm-cov
           cargo llvm-cov \
             --package ${{ matrix.crate }} \
             --release \


### PR DESCRIPTION
## Summary
- create the target/llvm-cov directory during the coverage enforcement step
- prevent cargo llvm-cov from failing when writing its LCOV report

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e812d3efac83259aee68a6edffaf7e