### PR TITLE
Ensure coverage output directory exists before running cargo llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         run: cargo test -p ${{ matrix.crate }} --release --all-features -- --nocapture
       - name: Enforce coverage (${{ matrix.crate }})
         run: |
+          mkdir -p target/llvm-cov
           cargo llvm-cov \
             --package ${{ matrix.crate }} \
             --release \


### PR DESCRIPTION
## Summary
- create the coverage output directory before invoking `cargo llvm-cov` in CI so the lcov report can be written without failing

## Testing
- make test *(fails: existing coverage thresholds for card-store below 100%)*

------
https://chatgpt.com/codex/tasks/task_e_68e812b1d38c8325952aea8ec8088e88