### PR TITLE
Fix scheduler card type alias and interval scaling

### DIFF
--- a/crates/scheduler-core/src/domain/card.rs
+++ b/crates/scheduler-core/src/domain/card.rs
@@ -3,22 +3,26 @@ use uuid::Uuid;
 
 use review_domain::Card as GenericCard;
 
-use crate::{CardKind, CardState, SchedulerConfig};
+use crate::config::SchedulerConfig;
 
-impl Card {
-    #[must_use]
-    pub fn new(owner_id: Uuid, kind: CardKind, today: NaiveDate, config: &SchedulerConfig) -> Self {
-        Self {
-            id: Uuid::new_v4(),
-            owner_id,
-            kind,
-            state: CardState::New,
-            ease_factor: config.initial_ease_factor,
-            interval_days: 0,
-            due: today,
-            lapses: 0,
-            reviews: 0,
-        }
+use super::{card_kind::CardKind, card_state::CardState, sm2_state::Sm2State};
+
+/// Specialized review card type for the scheduler domain.
+pub type Card = GenericCard<Uuid, Uuid, CardKind, Sm2State>;
+
+/// Constructs a new scheduler card using the provided configuration defaults.
+#[must_use]
+pub fn new_card(
+    owner_id: Uuid,
+    kind: CardKind,
+    today: NaiveDate,
+    config: &SchedulerConfig,
+) -> Card {
+    Card {
+        id: Uuid::new_v4(),
+        owner_id,
+        kind,
+        state: Sm2State::new(CardState::New, today, config.initial_ease_factor),
     }
 }
 

--- a/crates/scheduler-core/src/sm2.rs
+++ b/crates/scheduler-core/src/sm2.rs
@@ -66,30 +66,17 @@ fn easy_interval(previous_reviews: u32, previous_interval: u32, ease: f32) -> u3
     match previous_reviews {
         0 => 1,
         1 => 6,
-        _ => scaled_interval(previous_interval, ease * 1.3),
+        _ => scaled_interval(previous_interval, f64::from(ease) * 1.3),
     }
 }
 
-fn scaled_interval(previous_interval: u32, multiplier: f32) -> u32 {
-    let product = f64::from(previous_interval) * f64::from(multiplier);
+fn scaled_interval(previous_interval: u32, multiplier: f64) -> u32 {
+    let product = f64::from(previous_interval) * multiplier;
     let rounded = if product.is_finite() {
         product.round()
     } else {
         1.0
     };
-    let clamped = rounded.clamp(1.0, f64::from(u32::MAX));
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    {
-        clamped as u32
-    }
-}
-
-fn scaled_interval(previous_interval: u32, factor: f64) -> u32 {
-    let scaled = f64::from(previous_interval) * factor;
-    if !scaled.is_finite() {
-        return u32::MAX;
-    }
-    let rounded = scaled.round();
     let clamped = rounded.clamp(1.0, f64::from(u32::MAX));
     clamped
         .to_u32()


### PR DESCRIPTION
## Summary
- define the scheduler domain `Card` as a specialization of the shared review-domain type and expose a `new_card` helper function
- reuse the SM-2 interval scaling helper for all callers by accepting an `f64` multiplier

## Testing
- cargo test -p scheduler-core
- make test *(fails: coverage for crates/card-store remains below the enforced 100% threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68e8128b05ec8325b049c1d3ed1a1883