### PR TITLE
Fix lint issues across web-ui components

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -181,12 +181,28 @@ const App = (): JSX.Element => {
   const [isConsoleOpen, setIsConsoleOpen] = useState(false);
   const [importedLines, setImportedLines] = useState<ScheduledOpeningLine[]>([]);
   const navigate = useNavigate();
-  const dispatcher = useMemo(
+  const dispatcher: CommandDispatcher = useMemo(
     () =>
       createCommandDispatcher({
-        onUnknownCommand: (input) => window.alert(input),
+        onUnknownCommand: (input) => {
+          window.alert(input);
+        },
+        commands: [
+          {
+            command: 'cb',
+            handler: () => {
+              void navigate('/tools/board');
+            },
+          },
+          {
+            command: 'db',
+            handler: () => {
+              void navigate('/dashboard');
+            },
+          },
+        ],
       }),
-    [],
+    [navigate],
   );
 
   useEffect(() => {
@@ -234,15 +250,6 @@ const App = (): JSX.Element => {
   const handleCloseConsole = () => {
     setIsConsoleOpen(false);
   };
-
-  useEffect(() => {
-    dispatcher.register('cb', () => {
-      navigate('/tools/board');
-    });
-    dispatcher.register('db', () => {
-      navigate('/dashboard');
-    });
-  }, [dispatcher, navigate]);
 
   const handleExecuteCommand = useCallback(
     async (input: string) => {

--- a/web-ui/src/clients/__tests__/sessionGateway.test.ts
+++ b/web-ui/src/clients/__tests__/sessionGateway.test.ts
@@ -33,8 +33,7 @@ describe('sessionGateway', () => {
       }),
     );
     const firstCall = fetchMock.mock.calls[0];
-    expect(firstCall).not.toBeUndefined();
-    const init = Array.isArray(firstCall) ? firstCall[1] : undefined;
+    const init = firstCall[1];
     expect(init).toBeDefined();
     const headers = init?.headers;
     expect(headers).toBeInstanceOf(Headers);
@@ -69,8 +68,7 @@ describe('sessionGateway', () => {
       }),
     );
     const gradeCall = fetchMock.mock.calls[0];
-    expect(gradeCall).not.toBeUndefined();
-    const [, gradeInit] = gradeCall as Parameters<typeof fetch>;
+    const [, gradeInit] = gradeCall;
     expect(gradeInit).toBeDefined();
     const gradeHeaders = gradeInit?.headers;
     expect(gradeHeaders).toBeInstanceOf(Headers);

--- a/web-ui/src/clients/sessionGateway.ts
+++ b/web-ui/src/clients/sessionGateway.ts
@@ -20,7 +20,8 @@ const toRequestInit = (init: RequestConfig): RequestInit => {
     return normalizeConfig(init);
   }
 
-  const { body, ...rest } = init;
+  const rest = { ...init };
+  delete rest.body;
   return rest;
 };
 

--- a/web-ui/src/components/CommandConsole.tsx
+++ b/web-ui/src/components/CommandConsole.tsx
@@ -162,7 +162,12 @@ export const CommandConsole = ({
                   ×
                 </button>
               </div>
-              <form className="command-console__body" onSubmit={handleSubmit}>
+              <form
+                className="command-console__body"
+                onSubmit={(event) => {
+                  void handleSubmit(event);
+                }}
+              >
                 <span className="command-console__prompt">$:</span>
                 <input
                   ref={inputRef}
@@ -171,7 +176,9 @@ export const CommandConsole = ({
                   aria-label="Command input"
                   placeholder="Awaiting commands…"
                   value={command}
-                  onChange={(event) => setCommand(event.target.value)}
+                  onChange={(event) => {
+                    setCommand(event.target.value);
+                  }}
                   onKeyDown={handleKeyDown}
                 />
               </form>

--- a/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
+++ b/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
@@ -6,7 +6,6 @@ import type { Move } from 'chess.js';
 
 import type { CardSummary } from '../../types/gateway';
 import { OpeningReviewBoard } from '../OpeningReviewBoard';
-import type { ChessBoardElement } from 'chessboard-element';
 
 describe('OpeningReviewBoard', () => {
   afterEach(() => {
@@ -247,7 +246,7 @@ describe('OpeningReviewBoard', () => {
     const onResult = vi.fn();
     render(<OpeningReviewBoard card={startingPosition} onResult={onResult} />);
 
-    const board = screen.getByTestId('opening-review-board') as ChessBoardElement;
+    const board = screen.getByTestId('opening-review-board');
     const e2 = await findBoardSquare(board, 'e2');
 
     fireEvent.click(e2);
@@ -262,7 +261,7 @@ describe('OpeningReviewBoard', () => {
     const onResult = vi.fn();
     render(<OpeningReviewBoard card={startingPosition} onResult={onResult} />);
 
-    const board = screen.getByTestId('opening-review-board') as ChessBoardElement;
+    const board = screen.getByTestId('opening-review-board');
 
     fireEvent.click(await findBoardSquare(board, 'e2'));
     fireEvent.click(await findBoardSquare(board, 'e4'));
@@ -280,7 +279,7 @@ describe('OpeningReviewBoard', () => {
     const onResult = vi.fn();
     render(<OpeningReviewBoard card={startingPosition} onResult={onResult} />);
 
-    const board = screen.getByTestId('opening-review-board') as ChessBoardElement;
+    const board = screen.getByTestId('opening-review-board');
 
     fireEvent.click(await findBoardSquare(board, 'e2'));
     fireEvent.click(await findBoardSquare(board, 'e5'));
@@ -303,7 +302,7 @@ describe('OpeningReviewBoard', () => {
     const onResult = vi.fn();
     render(<OpeningReviewBoard card={startingPosition} onResult={onResult} />);
 
-    const board = screen.getByTestId('opening-review-board') as ChessBoardElement;
+    const board = screen.getByTestId('opening-review-board');
 
     const e7 = await findBoardSquare(board, 'e7');
     fireEvent.click(e7);
@@ -324,7 +323,7 @@ describe('OpeningReviewBoard', () => {
   });
 });
 
-async function findBoardSquare(board: ChessBoardElement, square: string): Promise<HTMLElement> {
+async function findBoardSquare(board: HTMLElement, square: string): Promise<HTMLElement> {
   return await waitFor(() => {
     const element = board.shadowRoot?.querySelector<HTMLElement>(`[data-square="${square}"]`);
     if (!element) {
@@ -335,7 +334,7 @@ async function findBoardSquare(board: ChessBoardElement, square: string): Promis
   });
 }
 
-function getOverlaySquare(board: ChessBoardElement, square: string): HTMLElement {
+function getOverlaySquare(board: HTMLElement, square: string): HTMLElement {
   const wrapper = board.parentElement;
   if (!wrapper) {
     throw new Error('Board wrapper is missing');

--- a/web-ui/src/pages/BlankBoardPage.tsx
+++ b/web-ui/src/pages/BlankBoardPage.tsx
@@ -101,7 +101,7 @@ export const BlankBoardPage: FC = () => {
           to,
           promotion: options.promotion ?? 'q',
         });
-      } catch (error) {
+      } catch {
         move = null;
       }
 

--- a/web-ui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/web-ui/src/pages/__tests__/DashboardPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 import { DashboardPage } from '../DashboardPage';
 import type { ReviewOverview } from '../../services/ReviewPlanner';
-import type { DetectedOpeningLine, ImportResult } from '../../types/repertoire';
+import type { ImportResult } from '../../types/repertoire';
 
 const buildOverview = (overrides: Partial<ReviewOverview> = {}): ReviewOverview => ({
   progress: {
@@ -47,7 +47,7 @@ const buildImportResult = (): ImportResult => ({
   },
 });
 
-const stubImportLine = (_line: DetectedOpeningLine): ImportResult => buildImportResult();
+const stubImportLine = (): ImportResult => buildImportResult();
 
 describe('DashboardPage', () => {
   it('enables navigation when an opening review can start', () => {

--- a/web-ui/src/types/chessboard-element.d.ts
+++ b/web-ui/src/types/chessboard-element.d.ts
@@ -6,8 +6,8 @@ type ChessBoardElementProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTM
 
 declare module 'react/jsx-runtime' {
   namespace JSX {
-    interface IntrinsicElements {
+    type IntrinsicElements = {
       'chess-board': ChessBoardElementProps;
-    }
+    };
   }
 }

--- a/web-ui/src/utils/commandDispatcher.ts
+++ b/web-ui/src/utils/commandDispatcher.ts
@@ -1,30 +1,38 @@
-export type CommandHandlerResult = void | string | Promise<void | string>;
+export type CommandHandlerResult = string | undefined | Promise<string | undefined>;
 
 export type CommandHandler = (command: string, args: string[]) => CommandHandlerResult;
 
 export type CommandDispatcher = {
-  register: (command: string, handler: CommandHandler) => void;
+  register: (command: string, handler: CommandHandler) => boolean;
+  unregister?: (command: string) => void;
   dispatch: (input: string) => Promise<void>;
 };
 
 export type CommandDispatcherOptions = {
   onUnknownCommand: (command: string) => void;
   onResult?: (message: string) => void;
+  commands?: Array<{ command: string; handler: CommandHandler }>;
 };
 
 export const createCommandDispatcher = ({
   onUnknownCommand,
   onResult,
+  commands,
 }: CommandDispatcherOptions): CommandDispatcher => {
   const handlers = new Map<string, CommandHandler>();
 
-  const register = (command: string, handler: CommandHandler) => {
+  const register = (command: string, handler: CommandHandler): boolean => {
     const key = command.trim().toLowerCase();
     if (!key) {
-      return;
+      return false;
     }
     handlers.set(key, handler);
+    return true;
   };
+
+  commands?.forEach(({ command, handler }) => {
+    register(command, handler);
+  });
 
   const dispatch = async (input: string) => {
     const trimmed = input.trim();


### PR DESCRIPTION
## Summary
- register dashboard navigation commands during command dispatcher creation and expose typed command registration helpers
- resolve async handler lint complaints across the command console and related tests
- tighten chessboard-related typing and error handling in the opening review flow and supporting pages/tests

## Testing
- npm run lint -- --max-warnings=0
- make test *(fails: cargo llvm-cov coverage thresholds in crates/card-store)*

------
https://chatgpt.com/codex/tasks/task_e_68e811fccb7c8325acd74fa5b50ec2f0