### PR TITLE
Add scheduler-core tests for uncovered logic

### DIFF
--- a/crates/scheduler-core/src/sm2.rs
+++ b/crates/scheduler-core/src/sm2.rs
@@ -149,6 +149,32 @@ mod tests {
     }
 
     #[test]
+    fn hard_interval_handles_first_reviews() {
+        assert_eq!(hard_interval(0, 10), 1);
+        assert_eq!(hard_interval(1, 10), 4);
+        assert_eq!(hard_interval(5, 10), 12);
+    }
+
+    #[test]
+    fn good_interval_handles_first_reviews() {
+        assert_eq!(good_interval(0, 1, 2.0), 1);
+        assert_eq!(good_interval(1, 1, 2.0), 6);
+        assert_eq!(good_interval(2, 10, 2.5), 25);
+    }
+
+    #[test]
+    fn easy_interval_handles_first_reviews() {
+        assert_eq!(easy_interval(0, 1, 2.0), 1);
+        assert_eq!(easy_interval(1, 1, 2.0), 6);
+        assert_eq!(easy_interval(3, 10, 2.0), 26);
+    }
+
+    #[test]
+    fn scaled_interval_handles_non_finite_product() {
+        assert_eq!(scaled_interval(5, f64::INFINITY), 1);
+    }
+
+    #[test]
     fn apply_sm2_updates_due_and_state() {
         let config = SchedulerConfig::default();
         let mut card = sample_card(CardState::Review);

--- a/crates/scheduler-core/tests/main_smoke.rs
+++ b/crates/scheduler-core/tests/main_smoke.rs
@@ -1,0 +1,7 @@
+#[test]
+fn main_runs_without_panicking() {
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_scheduler-core"))
+        .status()
+        .expect("binary should run");
+    assert!(status.success());
+}


### PR DESCRIPTION
## Summary
- add a smoke test that executes the scheduler-core binary main entry point
- extend queue and store unit tests to exercise unlock filtering edge cases and ordering logic
- add SM-2 interval unit tests and share the unlock candidate comparator for direct verification

## Testing
- cargo test -p scheduler-core
- cargo llvm-cov --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100 --show-missing-lines -q
- make test *(fails: card-store coverage remains below 100% in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68e817edfca48325b291ea6beabebb8c