### PR TITLE
Remove unused header destructuring in session gateway config

### DIFF
--- a/web-ui/src/clients/sessionGateway.ts
+++ b/web-ui/src/clients/sessionGateway.ts
@@ -40,7 +40,7 @@ async function request<T>(path: string, init?: RequestConfig): Promise<JsonShape
 function normalizeConfig(init: RequestConfigWithBody): RequestInit {
   const headers = new Headers(init.headers);
   headers.set('content-type', 'application/json');
-  const { body, headers: _headers, ...rest } = init;
+  const { body, ...rest } = init;
   return {
     ...rest,
     body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- simplify normalizeConfig by removing unused headers destructuring

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e81e27a57083258210af463800c879