### PR TITLE
Fix lint issues in web-ui session gateway and chessboard types

### DIFF
--- a/web-ui/src/clients/sessionGateway.ts
+++ b/web-ui/src/clients/sessionGateway.ts
@@ -6,9 +6,17 @@ import type {
 } from '../types/gateway';
 
 /* c8 ignore start */
-const env = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
-const baseUrlFromEnv =
-  env && typeof env.VITE_SESSION_URL === 'string' ? env.VITE_SESSION_URL : undefined;
+let baseUrlFromEnv: string | undefined;
+
+if (typeof import.meta !== 'undefined') {
+  const env: unknown = import.meta.env;
+  if (typeof env === 'object' && env !== null && 'VITE_SESSION_URL' in env) {
+    const envSessionUrl = (env as { VITE_SESSION_URL?: unknown }).VITE_SESSION_URL;
+    if (typeof envSessionUrl === 'string') {
+      baseUrlFromEnv = envSessionUrl;
+    }
+  }
+}
 const BASE_URL: string = baseUrlFromEnv ?? 'http://localhost:3000';
 
 type JsonShape<T> = T;
@@ -17,14 +25,15 @@ type RequestConfig = Omit<RequestInit, 'body'> & { body?: Record<string, unknown
 type RequestConfigWithBody = RequestConfig & { body: Record<string, unknown> };
 
 const hasBody = (config: RequestConfig): config is RequestConfigWithBody =>
-  typeof config.body === 'object' && config.body !== null;
+  config.body !== undefined;
 
 const toRequestInit = (init: RequestConfig): RequestInit => {
   if (hasBody(init)) {
     return normalizeConfig(init);
   }
 
-  const { body: _ignored, ...rest } = init;
+  const { body: _unusedBody, ...rest } = init;
+  void _unusedBody;
   return rest;
 };
 

--- a/web-ui/src/types/chessboard-element.d.ts
+++ b/web-ui/src/types/chessboard-element.d.ts
@@ -1,4 +1,5 @@
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
+import type * as React from 'react';
 
 type ChessBoardElementProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
   position?: string;
@@ -6,8 +7,8 @@ type ChessBoardElementProps = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTM
 
 declare module 'react/jsx-runtime' {
   namespace JSX {
-    interface IntrinsicElements {
+    type IntrinsicElements = React.JSX.IntrinsicElements & {
       'chess-board': ChessBoardElementProps;
-    }
+    };
   }
 }


### PR DESCRIPTION
## Summary
- guard access to the session gateway base URL with explicit runtime checks to satisfy lint rules
- simplify request body handling to avoid unused variables in the gateway client
- update the chessboard custom element declaration to use a type alias per lint requirements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e81f7fef348325be9239abe5c7ffac