### PR TITLE
Fix clippy lint in candidate ordering

### DIFF
--- a/crates/scheduler-core/src/store.rs
+++ b/crates/scheduler-core/src/store.rs
@@ -84,7 +84,7 @@ fn candidate_ordering(a: &Card, b: &Card) -> std::cmp::Ordering {
         }
         (CardKind::Opening(_), _) => std::cmp::Ordering::Less,
         (_, CardKind::Opening(_)) => std::cmp::Ordering::Greater,
-        _ => a.id.cmp(&b.id),
+        (CardKind::Tactic(_), CardKind::Tactic(_)) => a.id.cmp(&b.id),
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the wildcard arm in `candidate_ordering` with an explicit tactic variant match to satisfy clippy::match_wildcard_for_single_variants

## Testing
- cargo clippy -p scheduler-core --tests

------
https://chatgpt.com/codex/tasks/task_e_68e81fa1169c83259d9d41e9991845e5