### PR TITLE
Ensure review-domain helpers reach full coverage

### DIFF
--- a/crates/review-domain/src/card_kind.rs
+++ b/crates/review-domain/src/card_kind.rs
@@ -44,44 +44,40 @@ mod tests {
 
     #[test]
     fn map_opening_transforms_opening_variant() {
-        let card: CardKind<&str, ()> = CardKind::Opening("line");
+        let card: CardKind<&str, &str> = CardKind::Opening("line");
         let mapped: CardKind<usize, _> = card.map_opening(str::len);
-        assert!(matches!(mapped, CardKind::Opening(4)));
+        assert_eq!(mapped, CardKind::Opening(4));
     }
 
     #[test]
     fn map_opening_leaves_tactic_variant_untouched() {
-        let card: CardKind<&str, _> = CardKind::Tactic("fork");
+        let card: CardKind<&str, &str> = CardKind::Tactic("fork");
         let mapped = card.map_opening(str::len);
-        assert!(matches!(mapped, CardKind::Tactic("fork")));
+        assert_eq!(mapped, CardKind::Tactic("fork"));
     }
 
     #[test]
     fn map_tactic_transforms_tactic_variant() {
-        let card: CardKind<(), &str> = CardKind::Tactic("pin");
-        let mapped: CardKind<(), usize> = card.map_tactic(str::len);
-        assert!(matches!(mapped, CardKind::Tactic(3)));
+        let card: CardKind<&str, &str> = CardKind::Tactic("pin");
+        let mapped: CardKind<&str, usize> = card.map_tactic(str::len);
+        assert_eq!(mapped, CardKind::Tactic(3));
     }
 
     #[test]
     fn map_tactic_leaves_opening_variant_untouched() {
-        let card: CardKind<_, &str> = CardKind::Opening("Najdorf");
+        let card: CardKind<&str, &str> = CardKind::Opening("Najdorf");
         let mapped = card.map_tactic(str::len);
-        assert!(matches!(mapped, CardKind::Opening("Najdorf")));
+        assert_eq!(mapped, CardKind::Opening("Najdorf"));
     }
 
     #[test]
     fn as_ref_preserves_payload_references() {
-        let tactic = String::from("skewer");
-        let card: CardKind<(), String> = CardKind::Tactic(tactic.clone());
-        assert!(matches!(
-            card.as_ref(),
-            CardKind::Tactic(reference) if *reference == "skewer"
-        ));
-        let opening: CardKind<String, ()> = CardKind::Opening(String::from("Ruy Lopez"));
-        assert!(matches!(
-            opening.as_ref(),
-            CardKind::Opening(reference) if *reference == "Ruy Lopez"
-        ));
+        let tactic_payload = String::from("skewer");
+        let tactic_card: CardKind<String, String> = CardKind::Tactic(tactic_payload.clone());
+        assert_eq!(tactic_card.as_ref(), CardKind::Tactic(&tactic_payload));
+
+        let opening_payload = String::from("Ruy Lopez");
+        let opening_card: CardKind<String, String> = CardKind::Opening(opening_payload.clone());
+        assert_eq!(opening_card.as_ref(), CardKind::Opening(&opening_payload));
     }
 }

--- a/crates/review-domain/src/study_stage.rs
+++ b/crates/review-domain/src/study_stage.rs
@@ -67,9 +67,13 @@ mod tests {
     #[test]
     fn stage_helpers_cover_all_variants() {
         assert!(StudyStage::New.is_new());
+        assert!(!StudyStage::Learning.is_new());
         assert!(StudyStage::Learning.is_learning());
+        assert!(!StudyStage::Review.is_learning());
         assert!(StudyStage::Review.is_review());
+        assert!(!StudyStage::New.is_review());
         assert!(StudyStage::Relearning.is_relearning());
+        assert!(!StudyStage::Review.is_relearning());
         assert!(StudyStage::Learning.is_active());
         assert!(!StudyStage::New.is_active());
     }


### PR DESCRIPTION
## Summary
- rework review-domain CardKind tests to use consistent type parameters and direct equality checks so both match arms are exercised under coverage
- extend StudyStage helper tests with negative assertions to cover the false branches of the matcher helpers and restore full coverage

## Testing
- cargo test -p review-domain
- cargo llvm-cov --package review-domain --release --all-features --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100 --show-missing-lines


------
https://chatgpt.com/codex/tasks/task_e_68e81fc030008325abf83d016f7be2d8

## Summary by Sourcery

Ensure full coverage for review-domain helper methods by reworking CardKind tests and extending StudyStage tests with negative assertions.

Tests:
- Rework CardKind tests to use uniform type parameters and assert equality for map_opening, map_tactic, and as_ref, covering both enum variants
- Extend StudyStage helper tests with negative assertions to exercise the false branches of its predicates