### PR TITLE
Fix Clippy warnings in card-store

### DIFF
--- a/crates/card-store/src/memory/reviews.rs
+++ b/crates/card-store/src/memory/reviews.rs
@@ -52,7 +52,7 @@ fn interval_after_grade(interval: NonZeroU8, grade: u8) -> NonZeroU8 {
             let doubled = interval.get().saturating_mul(2);
             NonZeroU8::new(doubled).unwrap()
         }
-        _ => unreachable!(),
+        _ => panic!("grade must be between 0 and 4"),
     }
 }
 
@@ -68,7 +68,7 @@ fn ease_delta_for_grade(grade: u8) -> f32 {
         2 => -0.05,
         3 => 0.0,
         4 => 0.15,
-        _ => unreachable!(),
+        _ => panic!("grade must be between 0 and 4"),
     }
 }
 
@@ -175,14 +175,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "grade must be between 0 and 4")]
     fn interval_after_grade_panics_on_out_of_range_values() {
         let interval = NonZeroU8::new(3).unwrap();
         interval_after_grade(interval, 9);
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "grade must be between 0 and 4")]
     fn ease_delta_for_grade_panics_on_out_of_range_values() {
         ease_delta_for_grade(9);
     }

--- a/crates/card-store/tests/review_domain_helpers.rs
+++ b/crates/card-store/tests/review_domain_helpers.rs
@@ -19,12 +19,12 @@ fn card_kind_map_helpers_cover_all_variants() {
     let tactic_payload = String::from("skewer");
     match CardKind::<(), String>::Tactic(tactic_payload.clone()).as_ref() {
         CardKind::Tactic(reference) => assert_eq!(*reference, "skewer"),
-        CardKind::Opening(_) => panic!("expected tactic reference"),
+        CardKind::Opening(()) => panic!("expected tactic reference"),
     }
 
     let opening_payload = String::from("london");
     match CardKind::<String, ()>::Opening(opening_payload.clone()).as_ref() {
         CardKind::Opening(reference) => assert_eq!(*reference, "london"),
-        CardKind::Tactic(_) => panic!("expected opening reference"),
+        CardKind::Tactic(()) => panic!("expected opening reference"),
     }
 }


### PR DESCRIPTION
## Summary
- replace unreachable! cases in card-store memory reviews with explicit panic messages and align tests
- update review domain helper tests to use explicit unit patterns

## Testing
- cargo clippy -p card-store --tests

------
https://chatgpt.com/codex/tasks/task_e_68e8c9021c9c8325a4b4a11be7d089b6

## Summary by Sourcery

Fix Clippy warnings in the card-store crate by replacing unreachable! calls with explicit panics and aligning tests to expect precise panic messages and unit patterns.

Enhancements:
- Replace unreachable! cases in interval_after_grade and ease_delta_for_grade with panic! carrying explicit "grade must be between 0 and 4" messages
- Use explicit unit patterns in review_domain_helpers tests instead of wildcard patterns to cover all variants

Tests:
- Add expected message to #[should_panic] attributes for out-of-range grade tests
- Align match arms in review_domain_helpers tests to use explicit unit values in panic cases