### PR TITLE
Add GitHub Pages deployment workflow for web-ui

### DIFF
--- a/.github/workflows/deploy-web-ui.yml
+++ b/.github/workflows/deploy-web-ui.yml
@@ -1,0 +1,57 @@
+name: Deploy web-ui to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build web-ui
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-ui
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web-ui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build output
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web-ui/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the web-ui project and deploys it to GitHub Pages
- configure npm dependency caching, upload the Vite build output, and publish with the Pages deploy action

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e8ce199864832588329124d59731a0

## Summary by Sourcery

CI:
- Add GitHub Actions workflow to build the web-ui project and deploy it to GitHub Pages