### PR TITLE
Include grade value in review panic messages

### DIFF
--- a/crates/card-store/src/memory/reviews.rs
+++ b/crates/card-store/src/memory/reviews.rs
@@ -52,7 +52,7 @@ fn interval_after_grade(interval: NonZeroU8, grade: u8) -> NonZeroU8 {
             let doubled = interval.get().saturating_mul(2);
             NonZeroU8::new(doubled).unwrap()
         }
-        _ => panic!("grade must be between 0 and 4"),
+        _ => panic!("grade {grade} must be between 0 and 4"),
     }
 }
 
@@ -68,7 +68,7 @@ fn ease_delta_for_grade(grade: u8) -> f32 {
         2 => -0.05,
         3 => 0.0,
         4 => 0.15,
-        _ => panic!("grade must be between 0 and 4"),
+        _ => panic!("grade {grade} must be between 0 and 4"),
     }
 }
 
@@ -175,14 +175,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "grade must be between 0 and 4")]
+    #[should_panic(expected = "grade 9 must be between 0 and 4")]
     fn interval_after_grade_panics_on_out_of_range_values() {
         let interval = NonZeroU8::new(3).unwrap();
         interval_after_grade(interval, 9);
     }
 
     #[test]
-    #[should_panic(expected = "grade must be between 0 and 4")]
+    #[should_panic(expected = "grade 9 must be between 0 and 4")]
     fn ease_delta_for_grade_panics_on_out_of_range_values() {
         ease_delta_for_grade(9);
     }


### PR DESCRIPTION
## Summary
- include the invalid grade value in panic messages for review grade handling
- update review panic tests to expect the specific grade value in the message

## Testing
- `cargo clippy -p card-store --tests`


------
https://chatgpt.com/codex/tasks/task_e_68e8cf06d9c883258ab6bfc842cdb5c0

## Summary by Sourcery

Improve panic messages in review grade handling by including the invalid grade value and update tests accordingly

Enhancements:
- Include invalid grade value in panic messages for interval_after_grade and ease_delta_for_grade

Tests:
- Update panic tests to expect the specific grade value in the error message