### PR TITLE
Fix clippy pedantic lint in scheduler store tests

### DIFF
--- a/crates/scheduler-core/src/store.rs
+++ b/crates/scheduler-core/src/store.rs
@@ -202,7 +202,7 @@ mod tests {
             .iter()
             .filter_map(|card| match &card.kind {
                 CardKind::Opening(opening) => Some(opening.parent_prefix.clone()),
-                _ => None,
+                CardKind::Tactic(_) => None,
             })
             .collect();
         assert_eq!(prefixes, vec!["a".to_string(), "b".to_string()]);


### PR DESCRIPTION
## Summary
- replace wildcard match in scheduler store test with an explicit CardKind::Tactic arm to satisfy clippy::pedantic

## Testing
- cargo clippy -p scheduler-core --tests

------
https://chatgpt.com/codex/tasks/task_e_68e8cf58b0048325811b4df397a1ace4

## Summary by Sourcery

Tests:
- Replace wildcard match arm with explicit CardKind::Tactic in scheduler store tests to satisfy clippy::pedantic