### PR TITLE
Fix isSquare type guard

### DIFF
--- a/web-ui/src/components/OpeningReviewBoard.tsx
+++ b/web-ui/src/components/OpeningReviewBoard.tsx
@@ -311,7 +311,7 @@ function isSquare(value: unknown): value is Square {
     return false;
   }
 
-  return OVERLAY_SQUARE_SET.has(value);
+  return OVERLAY_SQUARE_SET.has(value as Square);
 }
 
 function extractTeachingArrow(meta?: CardSummary['meta']): string | null {


### PR DESCRIPTION
## Summary
- ensure the overlay square type guard only accepts known squares by asserting the checked value

## Testing
- npm run build --prefix web-ui

------
https://chatgpt.com/codex/tasks/task_e_68e8d19540208325a5bcfa8be3cf1d34