### PR TITLE
Fix square filtering for opening review board targets

### DIFF
--- a/web-ui/src/components/OpeningReviewBoard.tsx
+++ b/web-ui/src/components/OpeningReviewBoard.tsx
@@ -30,7 +30,7 @@ const RANKS = ['8', '7', '6', '5', '4', '3', '2', '1'] as const;
 const OVERLAY_SQUARES: Square[] = RANKS.flatMap((rank) =>
   FILES.map((file) => `${file}${rank}` as Square),
 );
-const OVERLAY_SQUARE_SET = new Set<Square>(OVERLAY_SQUARES);
+const OVERLAY_SQUARE_SET = new Set<string>(OVERLAY_SQUARES);
 
 export function OpeningReviewBoard({ card, onResult }: Props): JSX.Element {
   const boardRef = useRef<ChessBoardElement | null>(null);
@@ -215,7 +215,10 @@ export function OpeningReviewBoard({ card, onResult }: Props): JSX.Element {
       }
 
       setSelectedSquareState(square);
-      setLegalTargets(moves.map((move) => move.to));
+      const targets = moves
+        .map((move) => move.to)
+        .filter((target): target is Square => isSquare(target));
+      setLegalTargets(targets);
     };
 
     board.addEventListener('drop', handleDrop);


### PR DESCRIPTION
## Summary
- ensure legal target squares are validated before updating state in the opening review board
- align the overlay square set typing with the guard utility to satisfy TypeScript

## Testing
- npm run build --prefix web-ui

------
https://chatgpt.com/codex/tasks/task_e_68e8d19540208325a5bcfa8be3cf1d34