### PR TITLE
Add regression tests for OpeningReviewBoard square guard

### DIFF
--- a/web-ui/src/components/OpeningReviewBoard.tsx
+++ b/web-ui/src/components/OpeningReviewBoard.tsx
@@ -353,3 +353,7 @@ function toUci(move: Move): string {
 function chooseGrade(uci: string, expectedMoves: string[]): ReviewGrade {
   return expectedMoves.includes(uci) ? GOOD_RESULT : MISS_RESULT;
 }
+
+export const __testables = {
+  isSquare,
+};

--- a/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
+++ b/web-ui/src/components/__tests__/OpeningReviewBoard.test.tsx
@@ -5,7 +5,7 @@ import { Chess } from 'chess.js';
 import type { Move } from 'chess.js';
 
 import type { CardSummary } from '../../types/gateway';
-import { OpeningReviewBoard } from '../OpeningReviewBoard';
+import { OpeningReviewBoard, __testables } from '../OpeningReviewBoard';
 
 describe('OpeningReviewBoard', () => {
   afterEach(() => {
@@ -320,6 +320,25 @@ describe('OpeningReviewBoard', () => {
       },
       { timeout: 1500 },
     );
+  });
+});
+
+describe('isSquare', () => {
+  const { isSquare } = __testables;
+
+  it('rejects non-string values', () => {
+    expect(isSquare(42)).toBe(false);
+    expect(isSquare({})).toBe(false);
+  });
+
+  it('rejects strings that are not chessboard squares', () => {
+    expect(isSquare('foo')).toBe(false);
+    expect(isSquare('a9')).toBe(false);
+  });
+
+  it('accepts chessboard squares', () => {
+    expect(isSquare('a1')).toBe(true);
+    expect(isSquare('h8')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add regression tests confirming the OpeningReviewBoard square type guard rejects invalid values
- expose the `isSquare` helper through a test-only export for verification

## Testing
- npm run test --prefix web-ui -- --run src/components/__tests__/OpeningReviewBoard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e8d8501ec083259f0174d6610f2266