### PR TITLE
Refresh documentation and annotate public APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,356 +1,94 @@
-# chess-trainer
+# Chess Training Workspace
 
-> **Composable, open-source spaced-repetition training system for chess.**  
-> Import your PGNs or tactic packs, automatically build an **opening trie** and **tactics bank**, then review daily through an **Anki-style scheduler** and **interactive chessboard UI**.
+This repository hosts a collection of Rust crates and TypeScript applications that power a spaced-repetition training workflow for chess openings and tactics. The code is organised as a Cargo workspace with supporting Node.js and Vite projects for service orchestration and the browser UI.
 
----
-
-## Table of Contents
-
-1. [Overview](#overview)
-2. [Architecture](#architecture)
-3. [Component Responsibilities](#component-responsibilities)
-4. [Data Model](#data-model)
-5. [Development Workflow](#development-workflow)
-6. [Code Layout](#code-layout)
-7. [Service-Level Descriptions](#service-level-descriptions)
-8. [Build & Run](#build--run)
-9. [Typical Data Flow](#typical-data-flow)
-10. [Extending the System](#extending-the-system)
-11. [Testing](#testing)
-12. [Roadmap](#roadmap)
-13. [License](#license)
-
----
-
-## Overview
-
-**chess-trainer** is a modular Rust + Python + TypeScript project built around three principles:
-
-1. **Spaced Repetition, not memorization** — review openings and tactics using an Anki-compatible algorithm (SM-2/FSRS).  
-2. **Composable services** — every major subsystem is a self-contained crate or app (Rust core, Node session gateway, React UI, Python workers).  
-3. **Deterministic data model** — all chess data (positions, edges, tactics, cards) is canonicalized via FEN/UCIs and stable 64-bit hashes for reproducibility.
-
----
-
-## Architecture
+## Repository Layout
 
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│                          chess-trainer (workspace)                   │
-│                                                                      │
-│  ┌────────────────┐     ┌──────────────────┐     ┌─────────────────┐ │
-│  │ pgn-import     │ →→  │ scheduler-core   │ →→  │ session-gateway │ │
-│  │ (Rust)         │     │ (Rust)           │     │ (Node/TS)       │ │
-│  └────────────────┘     └──────────────────┘     └─────────────────┘ │
-│         │                               │                 │          │
-│         ▼                               ▼                 ▼          │
-│  ┌────────────────┐     ┌────────────────────────┐  ┌────────────────┐│
-│  │ tactics-store  │     │ openings-store (Postgres)│ │ web-ui (React)││
-│  │ (Rust/Python)  │     │ positions/edges/cards   │ │ chessboard.js  ││
-│  └────────────────┘     └────────────────────────┘  └────────────────┘│
-│         ▲                               ▲                 │          │
-│         │                               │                 ▼          │
-│  ┌────────────────┐     ┌────────────────────────┐  ┌────────────────┐│
-│  │ analysis-worker│ ←── │ review-logs (Python FSRS)│ │ redis / NATS ││
-│  │ (Python)       │     └────────────────────────┘  └────────────────┘│
-└──────────────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Component Responsibilities
-
-| Component | Language | Purpose |
-|------------|-----------|----------|
-| **pgn-import** | Rust | Parse PGNs → build **Opening Trie** + **Tactic Bank**; export to Postgres / JSONL. |
-| **scheduler-core** | Rust | Implements Anki-style SRS (SM-2/FSRS). Handles unlocking logic (“1 move/day, shared prefixes”). |
-| **openings-store / tactics-store** | Rust + SQL | Persist positions, edges, repertoires, and tactics. |
-| **session-gateway** | Node/TypeScript | Session API and WebSocket orchestration between browser and scheduler. |
-| **web-ui** | React/TypeScript | Interactive training front-end (chessboard.js, deck management, review stats). |
-| **analysis-worker** | Python | Optional: Stockfish annotations, FSRS parameter fitting from review logs. |
-| **infrastructure** | YAML / Docker | Postgres, Redis, Stockfish containers, local dev orchestration. |
-
----
-
-## Data Model
-
-### Core Entities
-
-| Entity | Description | Primary Key |
-|--------|--------------|--------------|
-| `positions` | Unique board states (full FEN) | hash(fen) |
-| `edges` | Directed move `(parent_fen, move_uci → child_fen)` | hash(parent_fen, move_uci) |
-| `repertoire_edges` | User repertoire membership for edges | (owner, rep_key, edge_id) |
-| `tactics` | Puzzles (FEN + principal variation UCIs) | hash(fen, pv_uci) |
-| `cards` | SRS units (opening edge or tactic) | auto/id |
-| `reviews` | Review logs (grade, latency, next interval/ease) | auto/id |
-| `unlock_ledger` | Daily log of newly unlocked opening moves | (user_id, date, edge_id) |
-
-All IDs are deterministic 64-bit FNV hashes to ensure idempotent imports.
-
----
-
-## Development Workflow
-
-1. **Import data**
-   ```bash
-   cargo run -p pgn-import -- \
-       --input ./data/repertoires/italian_and_scandi.pgn \
-       --owner "andy" \
-       --repertoire "Italian + Scandinavian" \
-       --out-positions ./out/positions.jsonl \
-       --out-edges ./out/edges.jsonl \
-       --out-tactics ./out/tactics.jsonl
-   ```
-
-2. **Load into the scheduler**
-   ```bash
-   cargo run -p scheduler-core -- seed ./out/edges.jsonl ./out/tactics.jsonl
-   ```
-
-3. **Start the session gateway and UI**
-   ```bash
-   pnpm run dev  # in /apps/web
-   pnpm run start:session  # in /apps/session-gateway
-   ```
-
-4. **Review your queue**
-   Open http://localhost:5173 → the dashboard shows due cards and today’s unlocked move.
-
----
-
-## Code Layout
-
-```
-chess-trainer/
-├── Cargo.toml                 # Workspace manifest
-├── README.md                  # This file
-├── crates/
-│   ├── pgn-import/            # PGN → Opening Trie + Tactics extractor
-│   ├── scheduler-core/        # SM-2/FSRS scheduling and unlock logic
-│   ├── openings-store/        # SQL persistence layer (optional)
-│   └── shared-models/         # Common structs & hashing utilities
+chess-training/
+├── Cargo.toml                 # Workspace manifest for Rust crates
+├── crates/                    # Core domain and service crates
+│   ├── card-store/            # Persistence abstractions and in-memory store
+│   ├── chess-training-pgn-import/ # PGN ingestion pipeline
+│   ├── review-domain/         # Shared domain types (cards, positions, grades)
+│   └── scheduler-core/        # SM-2 scheduling logic and queue construction
 ├── apps/
-│   ├── session-gateway/       # Node/TS server for live review sessions
-│   └── web/                   # React front-end
-├── workers/
-│   └── analysis/              # Python Stockfish + FSRS parameter fitter
-├── infrastructure/
-│   ├── docker-compose.yml     # Postgres, Redis, Stockfish
-│   ├── migrations/            # SQL migrations
-│   └── config/                # Default .env / settings
-└── tests/
-    └── data/                  # PGN fixtures for integration tests
+│   └── session-gateway/       # Node.js API that mediates review sessions
+├── web-ui/                    # React front-end for daily reviews
+├── docs/                      # Developer documentation and scripts
+└── src/                       # Binary entry point for ad-hoc experiments
 ```
 
----
+Each directory listed above includes its own README with implementation specifics and setup instructions.
 
-## Service-Level Descriptions
+## Components
 
-### 1. **pgn-import**
-- Parses PGN using `shakmaty`.
-- Validates SAN → UCI, applies moves to derive child FENs.
-- Deduplicates positions (by FEN) and edges (by `(parent_fen, move_uci)`).
-- Extracts `[FEN]`-tagged games into tactics.
-- Emits:
-  - JSONL snapshots (`positions`, `edges`, `tactics`)
-  - or writes directly to Postgres via the `Storage` trait.
-- [Detailed README → `crates/pgn-import/README.md`](./crates/pgn-import/README.md)
+### Rust Crates
 
-### 2. **scheduler-core**
-- Implements SRS logic:
-  - **SM-2** baseline (interval + ease factor)
-  - **FSRS** (stability, difficulty) extension
-- Enforces **unlock policy**:
-  - 1 new opening move per day per user (merged across shared prefixes)
-  - Tactics unaffected; imported directly as cards.
-- Provides Rust API and optional Axum HTTP endpoints:
-  - `GET /queue/today`
-  - `POST /review`
-- Tracks review metrics and next-due forecasts.
+| Crate | Purpose |
+| --- | --- |
+| `review-domain` | Defines reusable chess training data structures such as cards, unlock records, study stages, and deterministic hashing helpers. |
+| `card-store` | Provides storage traits and an in-memory reference implementation for persisting cards, positions, and unlock ledgers. |
+| `scheduler-core` | Implements the SM-2 spaced-repetition algorithm, unlock policy, and queue building for daily review sessions. |
+| `chess-training-pgn-import` | Normalises PGN data into the shared domain model, producing canonical positions, opening edges, and tactics. |
 
-### 3. **openings-store / tactics-store**
-- Shared Postgres schema for persistence.
-- `sqlx` migrations create `positions`, `edges`, `tactics`, `cards`, `reviews`.
-- Indices ensure `(parent_id, move_uci)` and `(fen)` uniqueness.
-- Schema versioned via `schema_version` constant in each crate.
+Crates depend on one another through re-exported domain types to ensure consistent data modelling across the workspace.
 
-### 4. **session-gateway (Node/TypeScript)**
-- Mediates browser sessions → scheduler-core via HTTP/WebSocket.
-- Keeps short-lived review sessions in Redis:
-  - active card
-  - move history / board state
-- Endpoints:
-  - `/api/session/start` – fetch next due card
-  - `/api/session/grade` – post result
-  - `/api/session/stats` – live metrics for UI
+### TypeScript Applications
 
-### 5. **web-ui (React)**
-- Built with **Vite + Tailwind**.
-- Components:
-  - `OpeningReviewBoard` – interactive chessboard.js board.
-  - `TacticReviewBoard` – puzzle interface (reveal/solve modes).
-  - `DeckManager` – manage repertoires and import new PGNs.
-  - `StatsDashboard` – review history and forecast.
-- Offline-first (PWA) with local cache sync to session gateway.
+| App | Purpose |
+| --- | --- |
+| `apps/session-gateway` | Express + WebSocket server that proxies browser requests to the scheduler, maintains short-lived session state, and emits live updates. |
+| `web-ui` | Vite-powered React UI that renders review queues using data from the session gateway. |
 
-### 6. **analysis-worker (Python)**
-- Optional background tasks:
-  - Run Stockfish analysis (`depth 12–20`) to annotate tactics or openings.
-  - Re-fit FSRS parameters from accumulated `reviews`.
-- Communicates over Redis or NATS queue.
-- Outputs JSONL/CSV summaries used by scheduler-core tuning.
+Both applications consume the Rust crates through HTTP APIs rather than through direct FFI bindings.
 
-### 7. **infrastructure**
-- **Postgres** – canonical data store.
-- **Redis** – ephemeral session & queue cache.
-- **Stockfish** – engine container for analysis workers.
-- Compose file exposes default ports (5432, 6379, 3000, 5173).
+## Getting Started
 
----
+### Prerequisites
 
-## Typical Data Flow
+* Rust toolchain (`rustup`, `cargo`) targeting stable.
+* Node.js 18+ with your preferred package manager (`npm`, `pnpm`, or `yarn`).
 
-```
-     ┌───────────┐
-     │  PGN File │
-     └─────┬─────┘
-           │ parse
-           ▼
- ┌────────────────────┐
- │ pgn-import (Rust)  │
- │ • Validates SAN    │
- │ • Builds trie       │
- │ • Extracts tactics  │
- └────────┬────────────┘
-          │ write
-          ▼
- ┌────────────────────┐
- │ openings-store /   │
- │ tactics-store (SQL)│
- └────────┬────────────┘
-          │ daily queue
-          ▼
- ┌────────────────────┐
- │ scheduler-core     │
- │ • SM-2 / FSRS      │
- │ • unlock 1 move/day│
- └────────┬────────────┘
-          │ serve API
-          ▼
- ┌────────────────────┐
- │ session-gateway    │
- │ • WebSocket bridge │
- └────────┬────────────┘
-          │
-          ▼
- ┌────────────────────┐
- │ web-ui (React)     │
- │ • Review board     │
- │ • Stats dashboard  │
- └────────────────────┘
-```
-
----
-
-## Extending the System
-
-| Goal | Where to plug in |
-|------|------------------|
-| **Add new tactic sources** | Extend `pgn-import/tactics.rs` or build a CSV importer crate. |
-| **Different SRS model** | Implement the `Scheduler` trait in `scheduler-core`. |
-| **Custom UI** | Consume the `/api/session` endpoints or reuse the React components. |
-| **Engine integrations** | Drop Python worker tasks into `workers/analysis/`. |
-| **Multi-user auth** | Extend session-gateway with JWT middleware. |
-
----
-
-## Testing
-
-### Unit Tests
-Each crate contains its own unit tests (`cargo test -p crate-name`).
-
-Key invariants tested:
-- Trie uniqueness (`(parent, move)` pair unique)
-- SAN↔UCI round-trip correctness
-- Idempotent imports (same PGN → same counts)
-- Scheduler interval updates deterministic given identical grades
-
-### Integration Tests
-`tests/integration_mvp.rs` runs:
-1. Import `tests/data/opening_and_tactic.pgn`
-2. Validate counts
-3. Re-import same file (dedupe)
-4. Ensure identical metrics
-
-### Frontend Tests
-Run `pnpm test` for Jest/React component coverage.
-
-### Coverage & Workspace Checks
-Run `make test` to execute formatting, linting, the full Rust test suite, and
-LLVM-based coverage verification. The coverage step depends on the
-[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) subcommand and the
-`llvm-tools-preview` rustup component. Install both once per development
-environment:
+### Building the Rust Workspace
 
 ```bash
-cargo install cargo-llvm-cov
-rustup component add llvm-tools-preview
+cargo check        # Type-check all crates
+cargo test         # Run unit tests across the workspace
 ```
 
-With those prerequisites satisfied, `make test` will fail the build unless the
-workspace maintains 100% line, function, and region coverage for the
-`chess-training-pgn-import` crate.
+### Running the Session Gateway
 
----
+```bash
+cd apps/session-gateway
+npm install
+npm run start
+```
 
-## Roadmap
+The gateway expects the scheduler service to be reachable via the `SCHEDULER_URL` environment variable. The default points to `http://localhost:4000`.
 
-| Milestone | Focus |
-|------------|--------|
-| **v0.1** | MVP: single-user, sequential import, in-memory + JSONL store. |
-| **v0.2** | Postgres storage + API endpoints for scheduler-core. |
-| **v0.3** | FSRS parameter fitting + Stockfish analysis worker. |
-| **v0.4** | PWA offline sync + user authentication. |
-| **v0.5** | Deck sharing, Lichess study import, multi-user scaling. |
+### Developing the Web UI
 
----
+```bash
+cd web-ui
+npm install
+npm run dev
+```
+
+The UI loads review data from the gateway at `http://localhost:3000` by default. Adjust the `.env` file in `web-ui/` to point at alternative endpoints.
+
+## Testing and Quality
+
+* `cargo test` executes unit tests for the Rust workspace.
+* `npm run test` within each Node project exercises JavaScript/TypeScript tests (where defined).
+* `make lint` and `make fmt` are available at the repository root for convenience wrappers around `cargo fmt`, `cargo clippy`, and ESLint.
+
+## Contributing
+
+1. Ensure unit tests pass across all affected crates and applications.
+2. Update documentation in the relevant directory to reflect behavioural or API changes.
+3. Submit pull requests with descriptive commit messages.
 
 ## License
 
-MIT © chess-trainer contributors
-
----
-
-## Quick Start (for developers)
-
-```bash
-# 1. Clone and enter
-git clone https://github.com/yourorg/chess-trainer.git
-cd chess-trainer
-
-# 2. Build Rust workspace
-cargo build
-
-# 3. Launch core services
-docker compose up -d postgres redis
-cargo run -p pgn-import -- --input ./tests/data/opening_and_tactic.pgn --owner test --repertoire demo
-cargo run -p scheduler-core
-
-# 4. Start UI
-pnpm install --prefix apps/web
-pnpm --prefix apps/web dev
-
-# 5. Open http://localhost:5173
-```
-
----
-
-### TL;DR
-
-- **Import PGN → Build Trie → Unlock Moves → Review Daily**
-- Rust handles all deterministic logic.
-- Python adds optional analysis.
-- TypeScript powers the interactive experience.
-- Everything is modular, reproducible, and testable.
+This project is distributed under the MIT License. See [`LICENSE`](LICENSE) for details.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,11 @@
+# Applications
+
+This directory groups the JavaScript and TypeScript applications that work alongside the Rust crates in the workspace. Each subdirectory contains its own tooling, configuration, and README that explain how to run or test that specific service.
+
+Current applications:
+
+| Directory | Description |
+| --- | --- |
+| `session-gateway/` | Express + WebSocket API that coordinates browser sessions with the scheduler service. |
+
+When adding a new application, include a README in the subdirectory with setup instructions and update this list to describe its responsibilities.

--- a/apps/session-gateway/README.md
+++ b/apps/session-gateway/README.md
@@ -1,0 +1,49 @@
+# Session Gateway
+
+The session gateway is a lightweight Express + WebSocket service that proxies requests between the browser front-end and the Rust-based scheduler. It maintains ephemeral session state, coordinates review actions, and streams updates to connected clients.
+
+## Features
+
+* **REST API** for starting sessions, grading cards, fetching stats, and ending sessions.
+* **WebSocket updates** so clients receive the next card and refreshed statistics in real time.
+* **Configurable scheduler client** that forwards requests to the `scheduler-core` HTTP surface.
+* **In-memory session store** for development and testing.
+
+## Getting Started
+
+```bash
+npm install
+npm run build      # or `npm run dev` for live reload
+npm start
+```
+
+Environment variables are loaded directly from `process.env`:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `PORT` | HTTP port to listen on. | `3000` |
+| `SCHEDULER_URL` | Base URL for the scheduler service. | `http://localhost:4000` |
+| `LOG_LEVEL` | Pino log level (`info`, `debug`, etc.). | `info` |
+
+## Testing
+
+```bash
+npm run test
+```
+
+Vitest covers request handlers, service logic, and the HTTP scheduler client. Add new tests alongside the code in `src/**/__tests__`.
+
+## Project Structure
+
+```
+src/
+├── broadcaster.ts          # WebSocket fan-out helper
+├── clients/                # Scheduler client implementations
+├── config.ts               # Environment parsing and validation
+├── server.ts               # Express routes and WebSocket wiring
+├── sessionService.ts       # Core session orchestration
+├── stores/                 # Session persistence adapters
+└── types.ts                # Shared TypeScript contracts
+```
+
+Each subdirectory includes a README when additional documentation is required.

--- a/apps/session-gateway/src/README.md
+++ b/apps/session-gateway/src/README.md
@@ -1,0 +1,13 @@
+# Session Gateway Source
+
+The source tree is organised to keep HTTP wiring, business logic, and integration points isolated from one another.
+
+* `broadcaster.ts` – manages WebSocket fan-out to subscribers by session id.
+* `clients/` – scheduler client implementations (currently HTTP based).
+* `config.ts` – runtime configuration derived from environment variables.
+* `server.ts` – Express routes, validation, and WebSocket upgrade handling.
+* `sessionService.ts` – core orchestration for session lifecycle and stats.
+* `stores/` – pluggable session persistence adapters; defaults to an in-memory map.
+* `types.ts` – TypeScript contracts shared across modules and tests.
+
+All exported functions and types include JSDoc comments to ensure IDEs and generated documentation reflect the current behaviour. When adding new modules, include a brief description here outlining their role within the service.

--- a/apps/session-gateway/src/broadcaster.ts
+++ b/apps/session-gateway/src/broadcaster.ts
@@ -10,12 +10,18 @@ const sendSafe = (socket: WebSocket, payload: Message) => {
   }
 };
 
+/**
+ * Broadcasts updates to all websocket clients connected to a session.
+ */
 export interface Broadcaster {
   register(sessionId: string, socket: WebSocket): void;
   unregister(sessionId: string, socket: WebSocket): void;
   broadcast(sessionId: string, payload: Message): void;
 }
 
+/**
+ * Create a broadcaster that fans updates out to registered websocket clients.
+ */
 export const createBroadcaster = (): Broadcaster => {
   const channels = new Map<string, Set<WebSocket>>();
 

--- a/apps/session-gateway/src/clients/README.md
+++ b/apps/session-gateway/src/clients/README.md
@@ -1,0 +1,5 @@
+# Scheduler Clients
+
+This folder contains adapters that allow the session gateway to communicate with the scheduling service. The default implementation, `httpSchedulerClient.ts`, issues JSON requests to the HTTP surface exposed by `scheduler-core`.
+
+When adding new transports (for example, gRPC or message queues), place the adapter here and expose a factory that returns the shared `SchedulerClient` interface from `types.ts`.

--- a/apps/session-gateway/src/clients/httpSchedulerClient.ts
+++ b/apps/session-gateway/src/clients/httpSchedulerClient.ts
@@ -17,6 +17,9 @@ const parseJson = async <T>(response: Response) => {
   return text.length ? (JSON.parse(text) as T) : ({} as T);
 };
 
+/**
+ * Create a scheduler client that talks to the HTTP scheduler service.
+ */
 export const createHttpSchedulerClient = (
   options: HttpSchedulerClientOptions,
 ): SchedulerClient => {

--- a/apps/session-gateway/src/config.ts
+++ b/apps/session-gateway/src/config.ts
@@ -11,6 +11,12 @@ const envSchema = z.object({
     .default('info'),
 });
 
+/**
+ * Runtime configuration values derived from the environment.
+ */
 export type GatewayConfig = z.infer<typeof envSchema>;
 
+/**
+ * Load and validate configuration from the ambient environment variables.
+ */
 export const loadConfig = (): GatewayConfig => envSchema.parse(process.env);

--- a/apps/session-gateway/src/index.ts
+++ b/apps/session-gateway/src/index.ts
@@ -9,6 +9,9 @@ import type { SessionState } from './types.js';
 
 const createLogger = (level: string) => pino({ level });
 
+/**
+ * Bootstrap the session gateway HTTP and WebSocket servers using the current environment configuration.
+ */
 export const startGateway = async () => {
   const config = loadConfig();
   const logger = createLogger(config.LOG_LEVEL);

--- a/apps/session-gateway/src/server.ts
+++ b/apps/session-gateway/src/server.ts
@@ -35,6 +35,9 @@ const asyncHandler =
     Promise.resolve(handler(req, res, next)).catch(next);
   };
 
+/**
+ * Create an Express application and WebSocket server that expose the session gateway API.
+ */
 export const createGatewayServer = (deps: GatewayDependencies) => {
   const broadcaster = createBroadcaster();
   const service = createSessionService({ ...deps, broadcaster });

--- a/apps/session-gateway/src/sessionService.ts
+++ b/apps/session-gateway/src/sessionService.ts
@@ -21,6 +21,9 @@ const computeAccuracy = (correct: number, total: number) =>
 
 const noop = () => undefined;
 
+/**
+ * Contract implemented by the session service orchestrating study sessions.
+ */
 export interface SessionService {
   start(userId: string): Promise<{
     sessionId: string;
@@ -63,6 +66,9 @@ const applyGrade = (
   return { ...current, currentCard: nextCard, stats, totalLatency };
 };
 
+/**
+ * Construct a session service backed by the provided dependencies.
+ */
 export const createSessionService = (
   deps: SessionServiceDependencies,
 ): SessionService => {

--- a/apps/session-gateway/src/stores/README.md
+++ b/apps/session-gateway/src/stores/README.md
@@ -1,0 +1,5 @@
+# Session Stores
+
+Session stores abstract how active sessions are persisted between HTTP requests and WebSocket messages. The default `inMemoryStore.ts` implementation is sufficient for local development and automated tests.
+
+To add a durable backing store (for example, Redis), create a new module that implements the `SessionStore` interface from `types.ts` and export a factory that mirrors the `createInMemorySessionStore` signature.

--- a/apps/session-gateway/src/stores/inMemoryStore.ts
+++ b/apps/session-gateway/src/stores/inMemoryStore.ts
@@ -1,5 +1,8 @@
 import { SessionStore } from '../types.js';
 
+/**
+ * Create a simple in-memory session store suitable for tests and local development.
+ */
 export const createInMemorySessionStore = <T>(): SessionStore<T> => {
   const sessions = new Map<string, T>();
   return {

--- a/apps/session-gateway/src/types.ts
+++ b/apps/session-gateway/src/types.ts
@@ -1,7 +1,13 @@
 /* c8 ignore file */
 
+/**
+ * Review grades supported by the scheduler API.
+ */
 export type ReviewGrade = 'Again' | 'Hard' | 'Good' | 'Easy';
 
+/**
+ * Minimal card payload returned to session clients.
+ */
 export interface CardSummary {
   card_id: string;
   kind: 'Opening' | 'Tactic';
@@ -10,12 +16,18 @@ export interface CardSummary {
   meta?: Record<string, string | number>;
 }
 
+/**
+ * Aggregated statistics for an in-flight study session.
+ */
 export interface SessionStats {
   reviews_today: number;
   accuracy: number;
   avg_latency_ms: number;
 }
 
+/**
+ * Contract implemented by scheduler clients consumed by the gateway.
+ */
 export interface SchedulerClient {
   fetchQueue(userId: string): Promise<CardSummary[]>;
   gradeCard(input: {
@@ -26,6 +38,9 @@ export interface SchedulerClient {
   }): Promise<CardSummary | null>;
 }
 
+/**
+ * Persistence abstraction used to store in-progress session state.
+ */
 export interface SessionStore<T> {
   create(sessionId: string, value: T): Promise<void>;
   get(sessionId: string): Promise<T | undefined>;
@@ -33,6 +48,9 @@ export interface SessionStore<T> {
   delete(sessionId: string): Promise<void>;
 }
 
+/**
+ * In-memory representation of a learner's active session.
+ */
 export interface SessionState {
   sessionId: string;
   userId: string;
@@ -42,6 +60,9 @@ export interface SessionState {
   totalLatency: number;
 }
 
+/**
+ * Dependencies required to construct the session gateway services.
+ */
 export interface GatewayDependencies {
   schedulerClient: SchedulerClient;
   sessionStore: SessionStore<SessionState>;

--- a/apps/session-gateway/tests/README.md
+++ b/apps/session-gateway/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Integration tests targeting the session gateway live in this directory. Tests are executed with Vitest via `npm run test`. Use these files to exercise HTTP routes and service interactions end-to-end.

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,12 @@
+# Rust Crates
+
+The `crates/` directory contains the Rust libraries that implement the chess training domain, scheduling algorithms, and supporting utilities. Each crate is a first-class Cargo package and can be built or tested independently.
+
+| Crate | Description |
+| --- | --- |
+| `review-domain/` | Canonical domain types shared across services (cards, positions, unlock records, hashes). |
+| `card-store/` | Persistence abstractions and in-memory store for positions, edges, cards, and unlocks. |
+| `scheduler-core/` | SM-2 scheduling engine, unlock policy, and queue construction logic. |
+| `chess-training-pgn-import/` | PGN ingestion pipeline that produces canonical positions, opening edges, and tactics. |
+
+Each crate contains a README detailing its API surface, configuration, and extension points. Use `cargo test -p <crate>` to execute unit tests for a specific package.

--- a/crates/card-store/src/chess_position.rs
+++ b/crates/card-store/src/chess_position.rs
@@ -1,3 +1,4 @@
 //! Compatibility re-exports for chess position types.
 
+/// Chess position and validation error shared with the review-domain crate.
 pub use review_domain::{ChessPosition, PositionError};

--- a/crates/card-store/src/errors.rs
+++ b/crates/card-store/src/errors.rs
@@ -1,3 +1,4 @@
 //! Compatibility re-exports for review domain errors.
 
+/// Error returned when a chess position fails validation.
 pub use review_domain::PositionError;

--- a/crates/card-store/src/lib.rs
+++ b/crates/card-store/src/lib.rs
@@ -1,16 +1,25 @@
 //! card-store — unified persistence traits and in-memory implementation.
 #![allow(unexpected_cfgs)]
 
+/// Chess position re-exports shared with review-domain.
 pub mod chess_position;
+/// Storage configuration helpers.
 pub mod config;
+/// Error compatibility types for persistence operations.
 pub mod errors;
+/// In-memory store implementation and helpers.
 pub mod memory;
+/// Domain model types tailored to storage needs.
 pub mod model;
+/// Persistence trait definitions used by services.
 pub mod store;
 
+/// Error returned when chess positions fail validation.
 pub use crate::errors::PositionError;
+/// Core store trait and error surface for persistence implementations.
 pub use crate::store::{CardStore, StoreError};
 
+/// Deterministic hashing helper shared with review-domain.
 pub use review_domain::hash64;
 
 #[cfg(test)]

--- a/crates/card-store/src/memory/mod.rs
+++ b/crates/card-store/src/memory/mod.rs
@@ -17,6 +17,7 @@ pub mod position_helpers;
 pub mod reviews;
 pub mod unlocks;
 
+/// Public entry point for the in-memory card-store implementation used in tests and demos.
 pub use in_memory_card_store::InMemoryCardStore;
 
 use cards::{borrow_card_for_review, collect_due_cards_for_owner, store_opening_card};

--- a/crates/card-store/src/model.rs
+++ b/crates/card-store/src/model.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+/// Re-export shared review-domain types to simplify crate consumers.
 pub use review_domain::{EdgeInput, OpeningCard, ReviewRequest, StoredCardState, TacticCard};
 
 use review_domain::{

--- a/crates/card-store/src/tests/mod.rs
+++ b/crates/card-store/src/tests/mod.rs
@@ -1,1 +1,2 @@
+/// Shared helpers for crate-level tests.
 pub mod util;

--- a/crates/card-store/src/tests/util.rs
+++ b/crates/card-store/src/tests/util.rs
@@ -1,9 +1,11 @@
 use crate::store::StoreError;
 
+/// Helper used in integration tests to detect invalid position errors.
 pub fn is_invalid_position(err: &StoreError) -> bool {
     matches!(err, StoreError::InvalidPosition(_))
 }
 
+/// Asserts that the provided error represents an invalid chess position.
 pub fn assert_invalid_position(err: &StoreError) {
     assert!(
         is_invalid_position(err),

--- a/crates/chess-training-pgn-import/src/config.rs
+++ b/crates/chess-training-pgn-import/src/config.rs
@@ -32,6 +32,7 @@ use clap::error::Result as ClapResult;
 use clap::{Arg, ArgAction, ArgMatches, Command, value_parser};
 use serde::Deserialize;
 
+/// Error type returned when configuration sources fail to parse or load.
 pub use crate::errors::ConfigError;
 use crate::errors::{IoError, ParseError};
 
@@ -39,10 +40,15 @@ use crate::errors::{IoError, ParseError};
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IngestConfig {
+    /// Enable tactic extraction from `[FEN]` tagged games.
     pub tactic_from_fen: bool,
+    /// Add FEN-rooted games to the opening trie when true.
     pub include_fen_in_trie: bool,
+    /// Require `[SetUp "1"]` whenever `[FEN]` is present.
     pub require_setup_for_fen: bool,
+    /// Skip games with malformed FEN headers instead of failing-fast.
     pub skip_malformed_fen: bool,
+    /// Maximum recursive annotation variation depth to traverse.
     pub max_rav_depth: u32,
 }
 

--- a/crates/chess-training-pgn-import/src/lib.rs
+++ b/crates/chess-training-pgn-import/src/lib.rs
@@ -1,9 +1,19 @@
+//! chess-training-pgn-import — ingest PGN repertoires into review-domain structures.
+
+/// Import configuration surface, including CLI defaults.
 pub mod config;
+/// Error types surfaced during configuration and parsing.
 pub mod errors;
+/// PGN importer implementation.
 pub mod importer;
+/// Intermediate data structures produced during import.
 pub mod model;
+/// Storage abstractions used by the importer.
 pub mod storage;
 
+/// Configuration parameters used to drive PGN ingestion.
 pub use crate::config::IngestConfig;
+/// Importer façade and error type exposed to binary crates.
 pub use crate::importer::{ImportError, Importer};
+/// In-memory storage implementation useful for tests and tooling.
 pub use crate::storage::ImportInMemoryStore;

--- a/crates/chess-training-pgn-import/src/model.rs
+++ b/crates/chess-training-pgn-import/src/model.rs
@@ -1,21 +1,29 @@
 use fnv::FnvHasher;
+/// Re-export of the shared opening edge structure from the review-domain crate.
 pub use review_domain::OpeningEdge;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+/// Schema version applied to hashed identifiers.
 pub const SCHEMA_VERSION: u32 = 1;
+/// Namespace seed used when hashing identifiers for reproducibility.
 pub const HASH_NAMESPACE: &str = "chess-training:pgn-import";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Position {
+    /// Stable identifier derived from hashing the FEN.
     pub id: u64,
+    /// Full FEN string describing the position.
     pub fen: String,
+    /// Side to move encoded as `'w'` or `'b'`.
     pub side_to_move: char,
+    /// Ply count from the start position.
     pub ply: u32,
 }
 
 impl Position {
+    /// Construct a position with a deterministic identifier derived from the FEN.
     #[must_use]
     pub fn new(fen: &str, side_to_move: char, ply: u32) -> Self {
         let id = hash_with_seed(HASH_NAMESPACE, SCHEMA_VERSION, &fen);
@@ -30,13 +38,16 @@ impl Position {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpeningEdgeRecord {
+    /// Canonical opening edge generated from the PGN game.
     #[serde(flatten)]
     pub edge: OpeningEdge,
+    /// Optional origin metadata for analytics or debugging.
     pub source_hint: Option<String>,
 }
 
 impl OpeningEdgeRecord {
     #[allow(clippy::too_many_arguments)]
+    /// Construct a canonical opening edge record from PGN move data.
     #[must_use]
     pub fn new(
         parent_id: u64,
@@ -53,12 +64,16 @@ impl OpeningEdgeRecord {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepertoireEdge {
+    /// Owner identifier for the repertoire.
     pub owner: String,
+    /// Logical grouping key for the repertoire.
     pub repertoire_key: String,
+    /// Identifier of the edge stored in the repertoire.
     pub edge_id: u64,
 }
 
 impl RepertoireEdge {
+    /// Construct a repertoire edge linking an owner, repertoire key, and opening edge.
     #[must_use]
     pub fn new(owner: &str, repertoire_key: &str, edge_id: u64) -> Self {
         Self {
@@ -71,14 +86,20 @@ impl RepertoireEdge {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Tactic {
+    /// Stable identifier derived from the FEN and principal variation.
     pub id: u64,
+    /// FEN string describing the tactic's starting position.
     pub fen: String,
+    /// Principal variation encoded as UCI moves.
     pub pv_uci: Vec<String>,
+    /// Optional tags applied to the tactic.
     pub tags: Vec<String>,
+    /// Optional hint describing the tactic's provenance.
     pub source_hint: Option<String>,
 }
 
 impl Tactic {
+    /// Construct a tactic entry with deterministic identifier based on the FEN and PV.
     #[must_use]
     pub fn new(
         fen: &str,

--- a/crates/chess-training-pgn-import/src/storage.rs
+++ b/crates/chess-training-pgn-import/src/storage.rs
@@ -14,9 +14,13 @@ use crate::model::{OpeningEdgeRecord, Position, RepertoireEdge, Tactic};
 /// Implementors should ensure that the storage is updated with the provided item, and that the return value accurately reflects
 /// whether the item was newly added or replaced an existing entry.
 pub trait Storage {
+    /// Insert or update a normalized position.
     fn upsert_position(&mut self, position: Position) -> UpsertOutcome;
+    /// Insert or update an opening edge.
     fn upsert_edge(&mut self, edge: OpeningEdgeRecord) -> UpsertOutcome;
+    /// Insert or update a repertoire edge record.
     fn upsert_repertoire_edge(&mut self, record: RepertoireEdge) -> UpsertOutcome;
+    /// Insert or update a tactic opportunity.
     fn upsert_tactic(&mut self, tactic: Tactic) -> UpsertOutcome;
 }
 
@@ -36,6 +40,7 @@ impl UpsertOutcome {
         matches!(self, Self::Inserted)
     }
 
+    /// Construct an [`UpsertOutcome`] from a boolean indicating insertion.
     pub const fn from_bool(inserted: bool) -> Self {
         if inserted {
             Self::Inserted
@@ -77,26 +82,31 @@ impl Storage for ImportInMemoryStore {
 }
 
 impl ImportInMemoryStore {
+    /// Construct a new empty in-memory store.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Return the positions currently stored.
     #[must_use]
     pub fn positions(&self) -> Vec<Position> {
         self.positions.values().cloned().collect()
     }
 
+    /// Return the opening edges currently stored.
     #[must_use]
     pub fn edges(&self) -> Vec<OpeningEdgeRecord> {
         self.edges.values().cloned().collect()
     }
 
+    /// Return the tactics currently stored.
     #[must_use]
     pub fn tactics(&self) -> Vec<Tactic> {
         self.tactics.values().cloned().collect()
     }
 
+    /// Return the repertoire edges currently stored.
     #[must_use]
     pub fn repertoire_edges(&self) -> Vec<RepertoireEdge> {
         self.repertoire_edges

--- a/crates/review-domain/README.md
+++ b/crates/review-domain/README.md
@@ -1,0 +1,26 @@
+# review-domain
+
+`review-domain` defines the core data structures used across the chess training workspace. These types are designed to be serialization-friendly and to share deterministic identifiers so that services can communicate without bespoke translation layers.
+
+## Highlights
+
+* Generic card representation that parameterises the owner, card kind, and scheduling state.
+* Opening and tactic payloads with deterministic hashing helpers.
+* Unlock record types for progressive content releases.
+* Study stage, review grade, and validated grade enums reused by the scheduler and storage layers.
+
+## Usage
+
+Add the crate to your `Cargo.toml` within the workspace:
+
+```toml
+review-domain = { path = "../review-domain" }
+```
+
+Then import the types you need:
+
+```rust
+use review_domain::{Card, OpeningCard, ReviewGrade, StudyStage};
+```
+
+Refer to the inline documentation (`cargo doc --open -p review-domain`) for detailed descriptions of each type.

--- a/crates/review-domain/src/lib.rs
+++ b/crates/review-domain/src/lib.rs
@@ -1,3 +1,5 @@
+//! Core domain types shared across the chess training back-end services.
+
 mod card;
 mod card_kind;
 mod card_state;
@@ -12,15 +14,27 @@ mod tactic;
 mod unlock;
 mod valid_grade;
 
+/// Generic flashcard definition used across services.
 pub use card::Card;
+/// High-level classification of review cards.
 pub use card_kind::CardKind;
+/// Scheduling metadata tracked for each stored card.
 pub use card_state::StoredCardState;
+/// Deterministic hashing helper backed by BLAKE3.
 pub use hash::hash64;
+/// Opening-focused request and payload types.
 pub use opening::{EdgeInput, OpeningCard, OpeningEdge};
+/// Normalized chess position representation and related errors.
 pub use position::{ChessPosition, PositionError};
+/// Review submission payload capturing user input.
 pub use review::ReviewRequest;
+/// Grading scale for spaced repetition reviews.
 pub use review_grade::ReviewGrade;
+/// Learning stage classification for cards.
 pub use study_stage::StudyStage;
+/// Tactic-focused card payloads.
 pub use tactic::TacticCard;
+/// Unlock record details for progressive content releases.
 pub use unlock::{UnlockDetail, UnlockRecord};
+/// Validated review grades and related errors.
 pub use valid_grade::{GradeError, ValidGrade};

--- a/crates/review-domain/src/valid_grade.rs
+++ b/crates/review-domain/src/valid_grade.rs
@@ -8,15 +8,14 @@ pub enum ValidGrade {
     Four = 4,
 }
 
+/// Errors produced when attempting to construct a [`ValidGrade`].
 #[derive(Debug, Clone, Copy)]
 pub enum GradeError {
     /// The provided grade was outside the supported range of 0-4.
-    GradeOutsideRangeError {
-        grade: u8,
-    },
-    InvalidGradeError {
-        grade: u8,
-    },
+    /// The provided grade was outside the supported range of 0-4.
+    GradeOutsideRangeError { grade: u8 },
+    /// The provided grade could not be interpreted as a known review grade.
+    InvalidGradeError { grade: u8 },
 }
 
 impl ValidGrade {
@@ -65,6 +64,7 @@ impl ValidGrade {
         (self as u8) >= 3
     }
 
+    /// Returns the multiplicative interval increment associated with the grade.
     #[must_use]
     pub fn to_interval_increment(self) -> u8 {
         match self {

--- a/crates/scheduler-core/src/config.rs
+++ b/crates/scheduler-core/src/config.rs
@@ -2,9 +2,13 @@
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SchedulerConfig {
+    /// Ease factor assigned to new cards on creation.
     pub initial_ease_factor: f32,
+    /// Lower bound applied to the ease factor after reviews.
     pub ease_minimum: f32,
+    /// Upper bound applied to the ease factor after reviews.
     pub ease_maximum: f32,
+    /// Minutes before each successive learning step becomes due.
     pub learning_steps_minutes: Vec<u32>,
 }
 

--- a/crates/scheduler-core/src/domain/card_kind.rs
+++ b/crates/scheduler-core/src/domain/card_kind.rs
@@ -3,10 +3,12 @@ use review_domain::CardKind as GenericCardKind;
 /// Payload describing an opening-based card within the scheduler.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SchedulerOpeningCard {
+    /// Identifier prefix tying the card back to its parent opening line.
     pub parent_prefix: String,
 }
 
 impl SchedulerOpeningCard {
+    /// Constructs an opening card payload for the provided parent prefix.
     #[must_use]
     pub fn new(parent_prefix: impl Into<String>) -> Self {
         Self {
@@ -20,6 +22,7 @@ impl SchedulerOpeningCard {
 pub struct SchedulerTacticCard;
 
 impl SchedulerTacticCard {
+    /// Constructs a tactic card payload.
     #[must_use]
     pub fn new() -> Self {
         Self

--- a/crates/scheduler-core/src/domain/card_state.rs
+++ b/crates/scheduler-core/src/domain/card_state.rs
@@ -1,1 +1,2 @@
+/// Scheduler-specific alias for the study stage tracked on each card.
 pub use review_domain::StudyStage as CardState;

--- a/crates/scheduler-core/src/domain/mod.rs
+++ b/crates/scheduler-core/src/domain/mod.rs
@@ -1,13 +1,21 @@
 //! Core scheduler domain structs shared across modules.
 
+/// Card definitions specialized for the scheduler.
 pub mod card;
+/// Card kind payloads used by the scheduler.
 pub mod card_kind;
+/// State transitions and learning stages tracked by the scheduler.
 pub mod card_state;
+/// Spaced repetition metadata stored alongside each card.
 pub mod sm2_state;
 
+/// Scheduler-specific card wrapper and constructor helpers.
 pub use card::{Card, new_card};
+/// Card kind payloads exposed to scheduler consumers.
 pub use card_kind::{CardKind, SchedulerOpeningCard, SchedulerTacticCard};
+/// Scheduler-specific card state enumeration.
 pub use card_state::CardState;
+/// SM-2 state tracked for each scheduled card.
 pub use sm2_state::Sm2State;
 
 use chrono::NaiveDate;
@@ -20,17 +28,23 @@ use review_domain::UnlockRecord as GenericUnlockRecord;
 /// Domain-specific payload stored for scheduler unlock events.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SchedulerUnlockDetail {
+    /// Identifier of the card that became available for study.
     pub card_id: Uuid,
+    /// Optional prefix used to group unlocks by their parent line.
     pub parent_prefix: Option<String>,
 }
 
 /// Unlock events emitted by the scheduler.
 pub type UnlockRecord = GenericUnlockRecord<Uuid, SchedulerUnlockDetail>;
 
+/// Result of recording a review, including the updated card state.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReviewOutcome {
+    /// Card after applying the review outcome.
     pub card: Card,
+    /// Due date before the review was processed.
     pub previous_due: NaiveDate,
+    /// Grade provided by the learner for the review.
     pub grade: ReviewGrade,
 }
 

--- a/crates/scheduler-core/src/errors.rs
+++ b/crates/scheduler-core/src/errors.rs
@@ -3,8 +3,10 @@
 use thiserror::Error;
 use uuid::Uuid;
 
+/// Errors produced by scheduler operations.
 #[derive(Debug, Error)]
 pub enum SchedulerError {
+    /// Raised when a requested card is not present in the backing store.
     #[error("card not found: {0}")]
     CardNotFound(Uuid),
 }

--- a/crates/scheduler-core/src/lib.rs
+++ b/crates/scheduler-core/src/lib.rs
@@ -1,20 +1,34 @@
 //! scheduler-core — SM-2 scheduling, unlock policy, and supporting types.
 
+/// Scheduler configuration options governing SM-2 behavior.
 pub mod config;
+/// Domain-specific data structures exposed by the scheduler.
 pub mod domain;
+/// Error type returned by scheduler operations.
 pub mod errors;
+/// Review queue construction helpers.
 pub mod queue;
+/// High-level scheduler façade orchestrating reviews.
 pub mod scheduler;
+/// SM-2 calculation utilities.
 pub mod sm2;
+/// Storage abstractions consumed by the scheduler.
 pub mod store;
 
+/// Configuration values used to tune the scheduler.
 pub use config::SchedulerConfig;
+/// Domain exports for cards, unlocks, and helper constructors.
 pub use domain::{
     Card, CardKind, CardState, ReviewOutcome, SchedulerOpeningCard, SchedulerTacticCard,
     SchedulerUnlockDetail, UnlockRecord, new_card,
 };
+/// Error returned when scheduling operations fail.
 pub use errors::SchedulerError;
+/// Build the review queue for a given study day.
 pub use queue::build_queue_for_day;
+/// Review grade shared with review-domain consumers.
 pub use review_domain::ReviewGrade;
+/// Scheduler façade orchestrating queue building and review processing.
 pub use scheduler::Scheduler;
+/// Storage trait and in-memory implementation used by the scheduler.
 pub use store::{CardStore, InMemoryStore};

--- a/crates/scheduler-core/src/queue.rs
+++ b/crates/scheduler-core/src/queue.rs
@@ -9,6 +9,7 @@ use crate::config::SchedulerConfig;
 use crate::domain::{Card, CardKind, CardState, SchedulerUnlockDetail, UnlockRecord};
 use crate::store::CardStore;
 
+/// Build the study queue for the given owner on the provided day.
 #[must_use]
 pub fn build_queue_for_day<S: CardStore>(
     store: &mut S,

--- a/crates/scheduler-core/src/scheduler.rs
+++ b/crates/scheduler-core/src/scheduler.rs
@@ -11,12 +11,14 @@ use crate::sm2::apply_sm2;
 use crate::store::CardStore;
 use review_domain::ReviewGrade;
 
+/// High-level façade coordinating scheduling operations for a single store implementation.
 pub struct Scheduler<S: CardStore> {
     store: S,
     config: SchedulerConfig,
 }
 
 impl<S: CardStore> Scheduler<S> {
+    /// Construct a scheduler backed by the provided store and configuration.
     #[must_use]
     pub fn new(store: S, config: SchedulerConfig) -> Self {
         Self { store, config }
@@ -49,11 +51,13 @@ impl<S: CardStore> Scheduler<S> {
         })
     }
 
+    /// Build the review and unlock queue for the specified owner on a given day.
     #[must_use]
     pub fn build_queue(&mut self, owner_id: Uuid, today: NaiveDate) -> Vec<Card> {
         build_queue_for_day(&mut self.store, &self.config, owner_id, today)
     }
 
+    /// Consume the scheduler and return the inner store for reuse.
     #[must_use]
     pub fn into_store(self) -> S {
         self.store

--- a/crates/scheduler-core/src/store.rs
+++ b/crates/scheduler-core/src/store.rs
@@ -7,15 +7,23 @@ use uuid::Uuid;
 
 use crate::domain::{Card, CardKind, CardState, UnlockRecord};
 
+/// Storage abstraction required by the scheduler to retrieve and persist cards.
 pub trait CardStore {
+    /// Fetch a card by identifier if it exists.
     fn get_card(&self, id: Uuid) -> Option<Card>;
+    /// Insert or update a card in the backing store.
     fn upsert_card(&mut self, card: Card);
+    /// Retrieve cards due for review on the given day.
     fn due_cards(&self, owner_id: Uuid, today: NaiveDate) -> Vec<Card>;
+    /// Fetch cards eligible to be unlocked for future study.
     fn unlock_candidates(&self, owner_id: Uuid) -> Vec<Card>;
+    /// Record a newly unlocked card.
     fn record_unlock(&mut self, record: UnlockRecord);
+    /// Retrieve unlock events that occurred on the provided day.
     fn unlocked_on(&self, owner_id: Uuid, day: NaiveDate) -> Vec<UnlockRecord>;
 }
 
+/// Reference in-memory implementation of [`CardStore`] used in tests.
 #[derive(Debug, Default)]
 pub struct InMemoryStore {
     cards: BTreeMap<Uuid, Card>,
@@ -23,6 +31,7 @@ pub struct InMemoryStore {
 }
 
 impl InMemoryStore {
+    /// Construct a new, empty in-memory store.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation
+
+This directory contains developer-facing documentation and helper scripts that complement the inline comments and crate READMEs.
+
+* `TYPE_INDEX.md` – generated overview of TypeScript types exported from the front-end and gateway.
+* `coverage-debug.md` – troubleshooting notes for coverage tooling in CI.
+* `generate_type_index.py` – utility script that keeps `TYPE_INDEX.md` in sync with the source tree.
+
+Regenerate the type index after modifying exported TypeScript types:
+
+```bash
+python docs/generate_type_index.py
+```
+
+Feel free to add additional guides or ADRs to this directory as new systems are introduced.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,3 @@
+# Binary Entry Point
+
+The `src/main.rs` file provides a simple executable target used for smoke-testing the workspace setup. Extend or replace this binary when experimenting with new crate integrations or CLI utilities.

--- a/web-ui/docs/README.md
+++ b/web-ui/docs/README.md
@@ -1,0 +1,7 @@
+# Web UI Documentation
+
+Supplemental documentation for the React front-end lives in this directory. Current contents:
+
+* `BOARD_OVERLAY_FIX.md` – notes on addressing board overlay issues when embedding `chessboard-element` components.
+
+Add additional guides here when documenting UI-specific quirks, architecture decisions, or troubleshooting steps.

--- a/web-ui/public/README.md
+++ b/web-ui/public/README.md
@@ -1,0 +1,3 @@
+# Public Assets
+
+Static assets served directly by Vite during development and production builds. Place icons, manifest files, and other resources that should be copied without bundling transformations into this directory.

--- a/web-ui/public/samples/README.md
+++ b/web-ui/public/samples/README.md
@@ -1,0 +1,3 @@
+# Sample Data
+
+Example assets consumed by the UI during development demos. Use this folder for CSV, PGN, or JSON files that illustrate expected payloads without connecting to live services.

--- a/web-ui/src/README.md
+++ b/web-ui/src/README.md
@@ -1,0 +1,15 @@
+# Web UI Source
+
+The React application is organised into feature-focused directories:
+
+* `clients/` – API clients that talk to the session gateway.
+* `components/` – Presentational and container components.
+* `fixtures/` – Mock data used in storybooks and tests.
+* `pages/` – Route-level components.
+* `services/` – Data-fetching and orchestration utilities.
+* `state/` – Global state management helpers.
+* `styles/` – Shared style primitives.
+* `types/` – TypeScript contracts shared within the UI.
+* `utils/` – Generic helpers and hooks.
+
+Each directory includes tests where applicable in an adjacent `__tests__` folder. When introducing a new feature area, add a README describing its purpose and key conventions.

--- a/web-ui/src/clients/README.md
+++ b/web-ui/src/clients/README.md
@@ -1,0 +1,3 @@
+# Clients
+
+HTTP and WebSocket clients used by the UI to communicate with backend services. Modules here should expose typed interfaces and keep network concerns isolated from components.

--- a/web-ui/src/components/README.md
+++ b/web-ui/src/components/README.md
@@ -1,0 +1,3 @@
+# Components
+
+React components grouped by feature. Co-locate component-specific hooks, styles, and tests beside their implementation. Re-export commonly used components from an index file for ergonomic imports.

--- a/web-ui/src/fixtures/README.md
+++ b/web-ui/src/fixtures/README.md
@@ -1,0 +1,3 @@
+# Fixtures
+
+Static data used in tests, stories, and manual QA. Keep fixtures lightweight and representative of real-world payloads returned by the session gateway.

--- a/web-ui/src/pages/README.md
+++ b/web-ui/src/pages/README.md
@@ -1,0 +1,3 @@
+# Pages
+
+Route-level components that compose services, state, and shared components into complete screens. Pages should avoid duplicating business logic by delegating to modules in `services/` or `state/`.

--- a/web-ui/src/services/README.md
+++ b/web-ui/src/services/README.md
@@ -1,0 +1,3 @@
+# Services
+
+Data-fetching and orchestration utilities that mediate between the UI and external APIs. Services should return typed results and remain framework agnostic so they can be reused across components and tests.

--- a/web-ui/src/state/README.md
+++ b/web-ui/src/state/README.md
@@ -1,0 +1,3 @@
+# State
+
+State management helpers, stores, and hooks that coordinate application-wide data. Keep modules here framework-friendly and ensure tests cover reducers or selectors.

--- a/web-ui/src/styles/README.md
+++ b/web-ui/src/styles/README.md
@@ -1,0 +1,3 @@
+# Styles
+
+Global style utilities, theme tokens, and CSS modules shared across the React application. Keep design-system specific guidance here for quick reference.

--- a/web-ui/src/types/README.md
+++ b/web-ui/src/types/README.md
@@ -1,0 +1,3 @@
+# Types
+
+Shared TypeScript interfaces, enums, and helpers. Keep definitions here slim and ensure they align with the payloads returned by backend services. Update `docs/TYPE_INDEX.md` after exporting new public types.

--- a/web-ui/src/utils/README.md
+++ b/web-ui/src/utils/README.md
@@ -1,0 +1,3 @@
+# Utils
+
+Generic utility functions and hooks that do not fit neatly into other categories. Utilities should be pure or easily testable to encourage reuse across the application.


### PR DESCRIPTION
## Summary
- rewrite the top-level README and add directory-level READMEs to describe the current workspace structure
- add rustdoc comments for all public exports across the core crates
- add JSDoc comments for the session gateway's public TypeScript APIs

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e95195549c83259c8b65f60cec81a9