### PR TITLE
Derive equality for GradeError

### DIFF
--- a/crates/review-domain/src/valid_grade.rs
+++ b/crates/review-domain/src/valid_grade.rs
@@ -9,7 +9,7 @@ pub enum ValidGrade {
 }
 
 /// Errors produced when attempting to construct a [`ValidGrade`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GradeError {
     /// The provided grade was outside the supported range of 0-4.
     /// The provided grade was outside the supported range of 0-4.
@@ -92,24 +92,6 @@ impl ValidGrade {
         }
     }
 }
-
-impl PartialEq for GradeError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                GradeError::GradeOutsideRangeError { grade: left },
-                GradeError::GradeOutsideRangeError { grade: right },
-            )
-            | (
-                GradeError::InvalidGradeError { grade: left },
-                GradeError::InvalidGradeError { grade: right },
-            ) => left == right,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for GradeError {}
 
 impl TryFrom<u8> for ValidGrade {
     type Error = GradeError;


### PR DESCRIPTION
## Summary
- derive `PartialEq` and `Eq` for `GradeError`
- remove the redundant manual equality implementations to resolve clippy pedantic lint

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e95e2f408c8325bacc36e9d4daf74b

## Summary by Sourcery

Derive PartialEq and Eq for GradeError and remove redundant manual implementations

Enhancements:
- Derive PartialEq and Eq for GradeError
- Remove manual PartialEq and Eq implementations for GradeError to resolve clippy pedantic lint