### PR TITLE
Add opening repertoire store domain model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 4
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +86,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "apache-avro"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
+dependencies = [
+ "apache-avro-derive",
+ "digest",
+ "lazy_static",
+ "libflate",
+ "log",
+ "num-bigint",
+ "quad-rand",
+ "rand",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "typed-builder",
+ "uuid",
+]
+
+[[package]]
+name = "apache-avro-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e317e411016923787d14f6deb741c1a1d036e64c2785b079747c852f7fae5ca4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +157,15 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -198,7 +268,7 @@ version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -227,6 +297,84 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -263,6 +411,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,7 +440,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -279,6 +458,12 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -311,13 +496,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -343,10 +534,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -379,6 +600,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +640,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +656,12 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quote"
@@ -424,14 +679,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+
+[[package]]
 name = "review-domain"
 version = "0.1.0"
 dependencies = [
+ "apache-avro",
  "blake3",
  "chrono",
  "serde",
+ "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustix"
@@ -548,6 +847,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,7 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -633,6 +951,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typed-builder"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,10 +994,23 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -879,3 +1236,23 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/crates/review-domain/Cargo.toml
+++ b/crates/review-domain/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2024"
 
 [features]
 serde = ["dep:serde"]
+avro = ["dep:apache-avro"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 blake3 = "1"
 thiserror = "1"
 serde = { version = "1", optional = true, features = ["derive"] }
+apache-avro = { version = "0.16", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/review-domain/README.md
+++ b/crates/review-domain/README.md
@@ -6,6 +6,7 @@
 
 * Generic card representation that parameterises the owner, card kind, and scheduling state.
 * Opening and tactic payloads with deterministic hashing helpers.
+* Opening repertoire aggregate that serializes to JSON or Avro for downstream services.
 * Unlock record types for progressive content releases.
 * Study stage, review grade, and validated grade enums reused by the scheduler and storage layers.
 

--- a/crates/review-domain/src/grade/conversions.rs
+++ b/crates/review-domain/src/grade/conversions.rs
@@ -19,16 +19,9 @@ pub fn from_u8(grade: u8) -> Result<ValidGrade, GradeError> {
 /// Creates a new `ValidGrade` if the provided value is between 0 and 4 inclusive.
 /// Returns a `GradeError` otherwise.
 /// # Errors
-/// Returns `GradeError::InvalidGradeError` if the provided value is not between 0 and 4 inclusive.
+/// Returns `GradeError::GradeOutsideRangeError` if the provided value is not between 0 and 4 inclusive.
 pub fn new(grade: u8) -> Result<ValidGrade, GradeError> {
-    match grade {
-        0 => Ok(ValidGrade::Zero),
-        1 => Ok(ValidGrade::One),
-        2 => Ok(ValidGrade::Two),
-        3 => Ok(ValidGrade::Three),
-        4 => Ok(ValidGrade::Four),
-        _ => Err(GradeError::InvalidGradeError { grade }),
-    }
+    from_u8(grade)
 }
 
 /// Converts a `ValidGrade` to a `u8`.
@@ -57,7 +50,7 @@ impl ValidGrade {
     /// Creates a new `ValidGrade` if the provided value is between 0 and 4 inclusive.
     /// Returns a `GradeError` otherwise.
     /// # Errors
-    /// Returns `GradeError::InvalidGradeError` if the provided value is not between 0 and 4 inclusive.
+    /// Returns `GradeError::GradeOutsideRangeError` if the provided value is not between 0 and 4 inclusive.
     pub fn new(grade: u8) -> Result<Self, GradeError> {
         new(grade)
     }

--- a/crates/review-domain/src/lib.rs
+++ b/crates/review-domain/src/lib.rs
@@ -8,6 +8,7 @@ pub mod hash;
 pub mod macros;
 pub mod opening;
 pub mod position;
+pub mod repertoire;
 pub mod review;
 pub mod review_grade;
 pub mod study_stage;
@@ -28,6 +29,8 @@ pub use hash::hash64;
 pub use opening::{EdgeInput, OpeningCard, OpeningEdge};
 /// Normalized chess position representation and related errors.
 pub use position::{ChessPosition, PositionError};
+/// Opening repertoire store and associated move representation.
+pub use repertoire::{Repertoire, RepertoireError, RepertoireMove};
 /// Review submission payload capturing user input.
 pub use review::ReviewRequest;
 /// Grading scale for spaced repetition reviews.

--- a/crates/review-domain/src/repertoire.rs
+++ b/crates/review-domain/src/repertoire.rs
@@ -1,0 +1,171 @@
+//! Canonical representation of stored opening repertoire moves.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Domain error produced when manipulating a [`Repertoire`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RepertoireError {
+    /// Placeholder error returned by not-yet-implemented operations.
+    #[error("repertoire operation '{operation}' is not implemented yet")]
+    NotImplemented { operation: &'static str },
+}
+
+impl RepertoireError {
+    /// Creates a [`RepertoireError::NotImplemented`] for the provided operation.
+    #[must_use]
+    pub const fn not_implemented(operation: &'static str) -> Self {
+        Self::NotImplemented { operation }
+    }
+}
+
+/// A single move stored within an opening repertoire.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct RepertoireMove {
+    /// Identifier of the originating position.
+    pub parent_id: u64,
+    /// Identifier of the resulting position.
+    pub child_id: u64,
+    /// Deterministic identifier of the represented opening edge.
+    pub edge_id: u64,
+    /// Move encoded in UCI notation.
+    pub move_uci: String,
+    /// Move encoded in SAN notation.
+    pub move_san: String,
+}
+
+impl RepertoireMove {
+    /// Builds a new [`RepertoireMove`] from the constituent identifiers and move notation.
+    #[must_use]
+    pub fn new(
+        edge_id: u64,
+        parent_id: u64,
+        child_id: u64,
+        move_uci: impl Into<String>,
+        move_san: impl Into<String>,
+    ) -> Self {
+        Self {
+            edge_id,
+            parent_id,
+            child_id,
+            move_uci: move_uci.into(),
+            move_san: move_san.into(),
+        }
+    }
+}
+
+/// Aggregated store for the opening moves a student has committed to memory.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Repertoire {
+    /// Friendly label describing the scope of the repertoire (e.g. "King's Indian Defence").
+    name: String,
+    /// Collection of moves that make up the repertoire.
+    moves: Vec<RepertoireMove>,
+}
+
+impl Repertoire {
+    /// Creates an empty repertoire with the provided descriptive name.
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            moves: Vec::new(),
+        }
+    }
+
+    /// Human readable label associated with the repertoire.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Immutable view of all moves currently tracked by the repertoire.
+    #[must_use]
+    pub fn moves(&self) -> &[RepertoireMove] {
+        &self.moves
+    }
+
+    /// Placeholder stub for inserting a move into the repertoire.
+    ///
+    /// The implementation will later enforce business rules around duplicates and merge
+    /// policies. For now it communicates intent through the returned error value.
+    pub fn add_move(&mut self, _move_entry: RepertoireMove) -> Result<(), RepertoireError> {
+        Err(RepertoireError::not_implemented("add_move"))
+    }
+
+    /// Placeholder stub for removing a move from the repertoire by its edge identifier.
+    ///
+    /// Future implementations will prune the internal store and return success if the move is
+    /// found. The current stub advertises the missing functionality to consumers.
+    pub fn remove_move(&mut self, _edge_id: u64) -> Result<(), RepertoireError> {
+        Err(RepertoireError::not_implemented("remove_move"))
+    }
+
+    /// Provides the Avro schema for [`Repertoire`] when the `avro` feature is enabled.
+    #[cfg(feature = "avro")]
+    #[must_use]
+    pub fn avro_schema() -> apache_avro::schema::Schema {
+        apache_avro::schema::Schema::parse_str(Self::AVRO_SCHEMA_JSON)
+            .expect("repertoire schema is valid")
+    }
+
+    /// Converts the repertoire into an Avro [`Value`](apache_avro::types::Value).
+    #[cfg(feature = "avro")]
+    #[must_use]
+    pub fn to_avro_value(&self) -> apache_avro::types::Value {
+        use apache_avro::types::Value;
+
+        Value::Record(vec![
+            ("name".into(), Value::String(self.name.clone())),
+            (
+                "moves".into(),
+                Value::Array(
+                    self.moves
+                        .iter()
+                        .map(RepertoireMove::to_avro_value)
+                        .collect(),
+                ),
+            ),
+        ])
+    }
+
+    #[cfg(feature = "avro")]
+    const AVRO_SCHEMA_JSON: &'static str = r#"{
+        "type": "record",
+        "name": "Repertoire",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "moves", "type": {"type": "array", "items": {
+                "type": "record",
+                "name": "RepertoireMove",
+                "fields": [
+                    {"name": "parent_id", "type": "string"},
+                    {"name": "child_id", "type": "string"},
+                    {"name": "edge_id", "type": "string"},
+                    {"name": "move_uci", "type": "string"},
+                    {"name": "move_san", "type": "string"}
+                ]
+            }}}
+        ]
+    }"#;
+}
+
+#[cfg(feature = "avro")]
+impl RepertoireMove {
+    fn to_avro_value(&self) -> apache_avro::types::Value {
+        use apache_avro::types::Value;
+
+        Value::Record(vec![
+            (
+                "parent_id".into(),
+                Value::String(self.parent_id.to_string()),
+            ),
+            ("child_id".into(), Value::String(self.child_id.to_string())),
+            ("edge_id".into(), Value::String(self.edge_id.to_string())),
+            ("move_uci".into(), Value::String(self.move_uci.clone())),
+            ("move_san".into(), Value::String(self.move_san.clone())),
+        ])
+    }
+}

--- a/crates/review-domain/src/valid_grade.rs
+++ b/crates/review-domain/src/valid_grade.rs
@@ -46,7 +46,7 @@ impl ValidGrade {
     /// Creates a new `ValidGrade` if the provided value is between 0 and 4
     /// inclusive. Returns a `GradeError` otherwise.
     /// # Errors
-    /// Returns `GradeError::InvalidGrade` if the provided value is not between
+    /// Returns `GradeError::GradeOutsideRangeError` if the provided value is not between
     /// 0 and 4 inclusive.
     pub fn new(grade: u8) -> Result<Self, GradeError> {
         Self::from_u8(grade)

--- a/crates/review-domain/tests/repertoire.rs
+++ b/crates/review-domain/tests/repertoire.rs
@@ -1,0 +1,39 @@
+use review_domain::repertoire::{Repertoire, RepertoireError, RepertoireMove};
+
+#[test]
+fn repertoire_collects_moves() {
+    let mut repertoire = Repertoire::new("e4 starts");
+    assert_eq!(repertoire.name(), "e4 starts");
+    assert!(repertoire.moves().is_empty());
+
+    let move_entry = RepertoireMove::new(1, 2, 3, "e2e4", "e4");
+    let result = repertoire.add_move(move_entry.clone());
+    assert_eq!(result, Err(RepertoireError::not_implemented("add_move")));
+    assert!(
+        repertoire.moves().is_empty(),
+        "stub should not mutate the repertoire yet"
+    );
+}
+
+#[test]
+fn remove_move_stub_returns_expected_error() {
+    let mut repertoire = Repertoire::new("queen's gambit");
+    let result = repertoire.remove_move(42);
+    assert_eq!(result, Err(RepertoireError::not_implemented("remove_move")));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn repertoire_serializes_to_json() {
+    let repertoire = Repertoire::new("catalan");
+    let json = serde_json::to_string(&repertoire).expect("serialization succeeds");
+    assert!(json.contains("catalan"));
+}
+
+#[cfg(feature = "avro")]
+#[test]
+fn repertoire_exposes_avro_schema() {
+    let schema = Repertoire::avro_schema();
+    let schema_json = schema.canonical_form();
+    assert!(schema_json.contains("Repertoire"));
+}

--- a/crates/review-domain/tests/valid_grade.rs
+++ b/crates/review-domain/tests/valid_grade.rs
@@ -92,7 +92,7 @@ fn try_from_rejects_invalid_grades() {
         let err: GradeError =
             ValidGrade::try_from(value).expect_err("grade should fail for invalid value");
 
-        assert_eq!(err_variant(err), ErrVariant::Invalid(value));
+        assert_eq!(err_variant(err), ErrVariant::OutsideRange(value));
     }
 }
 


### PR DESCRIPTION
## Summary
- add a repertoire aggregate and move struct to capture learned opening lines with JSON and Avro helpers
- expose the new module from the domain crate and update documentation to mention the repertoire store
- align grade conversion helpers and tests so that `ValidGrade::new` and `TryFrom` return the same error variant

## Testing
- cargo test -p review-domain
- cargo test -p review-domain --features serde,avro
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ea6038e1d88325b4804abc6848a772