### PR TITLE
Add CI wrapper to capture logs on exit code 1

### DIFF
--- a/.github/actions/run-with-error-logging/action.yml
+++ b/.github/actions/run-with-error-logging/action.yml
@@ -1,0 +1,54 @@
+name: Run with CI error logging
+description: Run a command and capture logs when it exits with code 1.
+inputs:
+  command:
+    description: Command to execute.
+    required: true
+  label:
+    description: Identifier used to name the log file.
+    required: false
+  working-directory:
+    description: Directory in which to run the command.
+    required: false
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      run: |
+        set -o pipefail
+
+        repo_root="$(pwd)"
+        workdir="${{ inputs.working-directory }}"
+        if [ -n "$workdir" ]; then
+          cd "$workdir"
+        fi
+
+        tmp_log="$(mktemp)"
+        tmp_script="$(mktemp)"
+
+        printf '%s\n' "${{ inputs.command }}" >"$tmp_script"
+
+        
+        bash "$tmp_script" 2>&1 | tee "$tmp_log"
+        status=${PIPESTATUS[0]}
+
+        if [ "$status" -eq 1 ]; then
+          mkdir -p "$repo_root/ci-errors"
+          label="${{ inputs.label }}"
+          if [ -z "$label" ]; then
+            label="step"
+          fi
+          safe_label=$(echo "$label" | tr '[:space:]/' '__')
+          safe_label=$(echo "$safe_label" | tr -cd '[:alnum:]_.-')
+          if [ -z "$safe_label" ]; then
+            safe_label="step"
+          fi
+          timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
+          dest="$repo_root/ci-errors/${timestamp}_${safe_label}.log"
+          cp "$tmp_log" "$dest"
+          echo "Saved CI error log to $dest"
+        fi
+
+        rm -f "$tmp_log" "$tmp_script"
+        exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,25 +40,40 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Format code (${{ matrix.crate }})
-        run: cargo fmt --package ${{ matrix.crate }}
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: cargo fmt --package ${{ matrix.crate }}
+          label: rust-fmt-${{ matrix.crate }}
       - name: Lint with clippy (${{ matrix.crate }})
-        run: cargo clippy -p ${{ matrix.crate }} --all-targets --all-features -- -D clippy::all -D clippy::pedantic
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: cargo clippy -p ${{ matrix.crate }} --all-targets --all-features -- -D clippy::all -D clippy::pedantic
+          label: clippy-${{ matrix.crate }}
       - name: Run tests in debug mode (${{ matrix.crate }})
-        run: cargo test -p ${{ matrix.crate }} --all-features -- --nocapture
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: cargo test -p ${{ matrix.crate }} --all-features -- --nocapture
+          label: test-debug-${{ matrix.crate }}
       - name: Run tests in release mode (${{ matrix.crate }})
-        run: cargo test -p ${{ matrix.crate }} --release --all-features -- --nocapture
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: cargo test -p ${{ matrix.crate }} --release --all-features -- --nocapture
+          label: test-release-${{ matrix.crate }}
       - name: Enforce coverage (${{ matrix.crate }})
-        run: |
-          mkdir -p target/llvm-cov
-          cargo llvm-cov \
-            --package ${{ matrix.crate }} \
-            --release \
-            --all-features \
-            --fail-under-lines 100 \
-            --fail-under-functions 100 \
-            --fail-under-regions 100 \
-            --show-missing-lines \
-            --lcov --output-path target/llvm-cov/${{ matrix.crate }}.lcov
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          label: coverage-${{ matrix.crate }}
+          command: |
+            mkdir -p target/llvm-cov
+            cargo llvm-cov \
+              --package ${{ matrix.crate }} \
+              --release \
+              --all-features \
+              --fail-under-lines 100 \
+              --fail-under-functions 100 \
+              --fail-under-regions 100 \
+              --show-missing-lines \
+              --lcov --output-path target/llvm-cov/${{ matrix.crate }}.lcov
 
   rust-fmt-workspace:
     name: Workspace formatting gate
@@ -74,7 +89,10 @@ jobs:
           toolchain: stable
           components: rustfmt
       - name: Format entire workspace
-        run: cargo fmt --all
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: cargo fmt --all
+          label: workspace-fmt
 
   javascript:
     name: 'JavaScript checks (${{ matrix.project }})'
@@ -102,73 +120,97 @@ jobs:
           cache: npm
           cache-dependency-path: ${{ matrix.path }}/package-lock.json
       - name: Install dependencies (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: npm ci --prefer-offline --no-audit --fund=false
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm ci --prefer-offline --no-audit --fund=false
+          label: npm-ci-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
       - name: Reformat (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: npm run format
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm run format
+          label: npm-format-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
       - name: Check formatting (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: npm run format:check
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm run format:check
+          label: npm-format-check-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
       - name: Lint (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: npm run lint -- --fix --max-warnings=0
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm run lint -- --fix --max-warnings=0
+          label: npm-lint-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
       - name: Type check (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: npm run typecheck
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm run typecheck
+          label: npm-typecheck-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
       - name: Run build (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: npm run build
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm run build
+          label: npm-build-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
       - name: Test with coverage (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text --run
+          label: npm-test-coverage-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
         env:
           CI: 'true'
-        run: npm run test:coverage -- --coverage.reporter=json-summary --coverage.reporter=text --run
       - name: Enforce 100% coverage (${{ matrix.project }})
-        working-directory: ${{ matrix.path }}
-        run: |
-          node - <<'NODE'
-          import fs from 'node:fs';
-          import path from 'node:path';
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          label: npm-enforce-coverage-${{ matrix.project }}
+          working-directory: ${{ matrix.path }}
+          command: |
+            node - <<'NODE'
+            import fs from 'node:fs';
+            import path from 'node:path';
 
-          const summaryPath = path.resolve('coverage', 'coverage-summary.json');
-          if (!fs.existsSync(summaryPath)) {
-            console.error(`Coverage summary not found at ${summaryPath}`);
-            process.exit(1);
-          }
-          const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
-          const total = summary.total;
-          const metrics = ['lines', 'statements', 'branches', 'functions'];
-          const failures = metrics.filter((metric) => {
-            const value = total?.[metric]?.pct ?? 0;
-            return typeof value !== 'number' || value < 100;
-          });
-          if (failures.length > 0) {
-            console.error('Coverage below 100% for metrics:', failures);
-            process.exit(1);
-          }
-          const filesBelowThreshold = Object.entries(summary)
-            .filter(([file]) => file !== 'total')
-            .flatMap(([file, metricSummary]) => {
-              return metrics
-                .filter((metric) => {
-                  const value = metricSummary?.[metric]?.pct;
-                  return typeof value !== 'number' || value < 100;
-                })
-                .map((metric) => {
-                  const value = metricSummary?.[metric]?.pct;
-                  return `${file} -> ${metric}: ${typeof value === 'number' ? value : 'N/A'}%`;
-                });
-            });
-          if (filesBelowThreshold.length > 0) {
-            console.error('Every file must maintain 100% coverage. The following entries failed:');
-            for (const entry of filesBelowThreshold) {
-              console.error(` - ${entry}`);
+            const summaryPath = path.resolve('coverage', 'coverage-summary.json');
+            if (!fs.existsSync(summaryPath)) {
+              console.error(`Coverage summary not found at ${summaryPath}`);
+              process.exit(1);
             }
-            process.exit(1);
-          }
-          console.log('Coverage check passed with 100% across all metrics.');
-          NODE
+            const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+            const total = summary.total;
+            const metrics = ['lines', 'statements', 'branches', 'functions'];
+            const failures = metrics.filter((metric) => {
+              const value = total?.[metric]?.pct ?? 0;
+              return typeof value !== 'number' || value < 100;
+            });
+            if (failures.length > 0) {
+              console.error('Coverage below 100% for metrics:', failures);
+              process.exit(1);
+            }
+            const filesBelowThreshold = Object.entries(summary)
+              .filter(([file]) => file !== 'total')
+              .flatMap(([file, metricSummary]) => {
+                return metrics
+                  .filter((metric) => {
+                    const value = metricSummary?.[metric]?.pct;
+                    return typeof value !== 'number' || value < 100;
+                  })
+                  .map((metric) => {
+                    const value = metricSummary?.[metric]?.pct;
+                    return `${file} -> ${metric}: ${typeof value === 'number' ? value : 'N/A'}%`;
+                  });
+              });
+            if (filesBelowThreshold.length > 0) {
+              console.error('Every file must maintain 100% coverage. The following entries failed:');
+              for (const entry of filesBelowThreshold) {
+                console.error(` - ${entry}`);
+              }
+              process.exit(1);
+            }
+            console.log('Coverage check passed with 100% across all metrics.');
+            NODE
 
   required:
     name: Require successful jobs
@@ -179,4 +221,7 @@ jobs:
       - javascript
     steps:
       - name: Confirm all checks passed
-        run: echo "All checks succeeded."
+        uses: ./.github/actions/run-with-error-logging
+        with:
+          command: echo "All checks succeeded."
+          label: confirm-success

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist/**/
 apps/session-gateway/dist/
 web-ui/dist/
 
+ci-errors/
+
 lcov-report/
 **/lcov-report/
 apps/session-gateway/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json


### PR DESCRIPTION
## Summary
- add a composite GitHub Action that wraps commands and captures their output when they exit with status code 1
- refactor the CI workflow to run every script step through the new wrapper so failures copy logs into a `ci-errors` directory at the repository root
- ignore the generated `ci-errors/` directory in version control

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ea6a4551708325aedc985a99fee7cd