### PR TITLE
Fix duplicate IDs in PGN import pane

### DIFF
--- a/docs/issue-172-status.md
+++ b/docs/issue-172-status.md
@@ -1,0 +1,23 @@
+# Issue #172: Duplicate textarea IDs in PGN import panel
+
+## Context
+- **Issue:** [#172](https://github.com/aaweaver-actuary/chess-training/issues/172)
+- **Created:** 2025-10-11T14:29:28Z
+- **Assignee:** _Unassigned_
+- **Status:** Open
+
+## Current observations
+- The PGN import pane renders two `<textarea>` elements that both use the `id="pgn-import-textarea"` attribute, one in paste mode and one in upload mode. This duplicates the HTML `id` and breaks the one-to-one relationship expected by assistive technologies and `label` elements.
+- Both labels in each mode point at the shared `id`, so whichever textarea renders last will be associated with both labels, creating confusing focus and accessibility semantics.
+
+Relevant source lines:
+- `web-ui/src/components/PgnImportPane.tsx`, lines 334-399.
+
+## Suggested next steps
+- Give the upload-mode textarea a distinct identifier (for example, `pgn-import-review-textarea`) and update its associated `<label>`.
+- Add a unit test in the PGN import pane test suite that mounts the component in both modes and asserts that the textareas expose distinct `id` attributes. This would prevent regressions.
+- Manually verify the PGN import workflow in both paste and upload modes after adjusting identifiers to ensure no references or CSS selectors rely on the old value.
+
+## Notes
+- No active development is tracked on this issue (no assignee or linked pull request).
+- No automated tests or builds were executed during this triage step.

--- a/web-ui/src/components/PgnImportPane.tsx
+++ b/web-ui/src/components/PgnImportPane.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, FocusEvent, JSX } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import './PgnImportPane.css';
 import type { DetectedOpeningLine, ImportResult } from '../types/repertoire';
@@ -118,6 +118,8 @@ export const PgnImportPane = ({
   commandDispatcher,
 }: PgnImportPaneProps): JSX.Element => {
   const containerRef = useRef<HTMLElement | null>(null);
+  const pasteTextareaDomId = `pgn-import-textarea-paste-${useId()}`;
+  const uploadTextareaDomId = `pgn-import-textarea-upload-${useId()}`;
   const [isExpanded, setIsExpanded] = useState(false);
   type ImportMode = 'idle' | 'paste' | 'upload';
   const [mode, setMode] = useState<ImportMode>('idle');
@@ -354,11 +356,11 @@ export const PgnImportPane = ({
 
           {isPasteMode ? (
             <div className="pgn-import-form" role="region" aria-label="Paste PGN">
-              <label className="pgn-import-label" htmlFor="pgn-import-textarea">
+              <label className="pgn-import-label" htmlFor={pasteTextareaDomId}>
                 Paste moves
               </label>
               <textarea
-                id="pgn-import-textarea"
+                id={pasteTextareaDomId}
                 value={pgnText}
                 onChange={(event) => {
                   handlePgnChange(event.target.value);
@@ -382,11 +384,11 @@ export const PgnImportPane = ({
                 aria-label="Upload PGN file"
                 onChange={handleFileChange}
               />
-              <label className="pgn-import-label" htmlFor="pgn-import-textarea">
+              <label className="pgn-import-label" htmlFor={uploadTextareaDomId}>
                 Review moves
               </label>
               <textarea
-                id="pgn-import-textarea"
+                id={uploadTextareaDomId}
                 value={pgnText}
                 onChange={(event) => {
                   handlePgnChange(event.target.value);

--- a/web-ui/src/components/__tests__/PgnImportPane.test.tsx
+++ b/web-ui/src/components/__tests__/PgnImportPane.test.tsx
@@ -516,6 +516,52 @@ describe('PgnImportPane', () => {
     expect(fileInput).toHaveAttribute('type', 'file');
   });
 
+  it('assigns distinct textarea ids to paste and upload modes', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PgnImportPane
+        onImportLine={() => ({
+          added: false,
+          line: {
+            id: 'upload-id-test',
+            opening: 'Danish Gambit',
+            color: 'White',
+            moves: [],
+            display: '',
+            scheduledFor: new Date().toISOString(),
+          },
+        })}
+      />,
+    );
+
+    const handle = screen.getByRole('button', { name: /open pgn import tools/i });
+    fireEvent.pointerEnter(handle);
+
+    const pasteOption = await screen.findByRole('button', { name: /paste pgn/i });
+    await user.click(pasteOption);
+
+    const pasteLabel = await screen.findByText(/paste moves/i);
+    const pasteTextarea = await screen.findByLabelText(/pgn move input/i);
+    expect(pasteTextarea).toHaveAttribute('id');
+    const pasteTextareaId = pasteTextarea.getAttribute('id');
+    expect(pasteTextareaId).not.toBeNull();
+    expect(pasteLabel).toHaveAttribute('for', pasteTextareaId as string);
+
+    const uploadOption = await screen.findByRole('button', { name: /upload pgn/i });
+    await user.click(uploadOption);
+
+    const uploadLabel = await screen.findByText(/review moves/i);
+    const uploadTextarea = await screen.findByLabelText(/pgn move input/i);
+    expect(uploadTextarea).toHaveAttribute('id');
+    const uploadTextareaId = uploadTextarea.getAttribute('id');
+    expect(uploadTextareaId).not.toBeNull();
+    expect(uploadLabel).toHaveAttribute('for', uploadTextareaId as string);
+
+    expect(uploadTextarea).not.toBe(pasteTextarea);
+    expect(uploadTextareaId).not.toEqual(pasteTextareaId);
+  });
+
   it('treats uploaded PGNs the same as pasted PGNs', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- generate unique IDs for the PGN paste and upload textareas so their labels stay in sync
- add a regression test that exercises both import modes and asserts the IDs differ

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ea758ca6048325aded32fba4b79ba4