### PR TITLE
Refactor dashboard session routing for better modularity

### DIFF
--- a/web-ui/src/App.tsx
+++ b/web-ui/src/App.tsx
@@ -1,174 +1,25 @@
 import type { JSX } from 'react';
-
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import './App.css';
-import { sampleSnapshot } from './fixtures/sampleSnapshot';
-import { DashboardPage } from './pages/DashboardPage';
-import { BlankBoardPage } from './pages/BlankBoardPage';
-import { OpeningReviewPage } from './pages/OpeningReviewPage';
-import { ReviewPlanner } from './services/ReviewPlanner';
-import type { ReviewOverview } from './services/ReviewPlanner';
-import type { CardSummary, ReviewGrade } from './types/gateway';
-import { sessionStore } from './state/sessionStore';
 import { CommandConsole } from './components/CommandConsole';
+import { SessionRoutes } from './components/SessionRoutes';
 import type { DetectedOpeningLine, ImportResult, ScheduledOpeningLine } from './types/repertoire';
 import { createCommandDispatcher } from './utils/commandDispatcher';
 import type { CommandDispatcher, CommandHandler } from './utils/commandDispatcher';
-
-const planner = new ReviewPlanner();
-const baselineOverview = planner.buildOverview(sampleSnapshot);
-
-const useSessionState = () =>
-  useSyncExternalStore(sessionStore.subscribe, sessionStore.getState, sessionStore.getState);
-
-const buildOverview = (stats: ReturnType<typeof sessionStore.getState>['stats']) => {
-  const baseline = baselineOverview;
-  if (!stats) {
-    return baseline;
-  }
-
-  const totalDue = stats.due_count;
-  const completed = stats.completed_count;
-  const remaining = Math.max(totalDue - completed, 0);
-  const completionRate = totalDue === 0 ? 1 : completed / totalDue;
-
-  return {
-    ...baseline,
-    progress: {
-      ...baseline.progress,
-      totalDue,
-      completedToday: completed,
-      remaining,
-      completionRate,
-      accuracyRate: stats.accuracy,
-    },
-  };
-};
-
-const scheduleDateForLine = (offset: number): string => {
-  const base = new Date();
-  base.setDate(base.getDate() + 1 + offset);
-  return base.toISOString().slice(0, 10);
-};
-
-const scheduleOpeningLine = (line: DetectedOpeningLine, offset: number): ScheduledOpeningLine => ({
-  ...line,
-  id: ['import', Date.now().toString(), offset.toString()].join('-'),
-  scheduledFor: scheduleDateForLine(offset),
-});
-
-const linesMatch = (candidate: ScheduledOpeningLine, target: DetectedOpeningLine): boolean =>
-  candidate.opening === target.opening &&
-  candidate.color === target.color &&
-  candidate.moves.length === target.moves.length &&
-  candidate.moves.every((move, index) => move.toLowerCase() === target.moves[index]?.toLowerCase());
-
-const augmentOverviewWithImports = (
-  overview: ReviewOverview,
-  lines: ScheduledOpeningLine[],
-): ReviewOverview => ({
-  ...overview,
-  upcomingUnlocks: [
-    ...overview.upcomingUnlocks,
-    ...lines.map((line) => ({
-      id: line.id,
-      move: `${line.opening} (${line.color})`,
-      idea: `Line: ${line.display}`,
-      scheduledFor: line.scheduledFor,
-    })),
-  ],
-});
-
-type SessionRoutesProps = {
-  importedLines: ScheduledOpeningLine[];
-  onImportLine: (line: DetectedOpeningLine) => ImportResult;
-  commandDispatcher?: CommandDispatcher;
-};
-
-const useStartTimestamp = (card?: CardSummary) => {
-  const startedAtRef = useRef<number>(performance.now());
-  useEffect(() => {
-    if (card) {
-      startedAtRef.current = performance.now();
-    }
-  }, [card]);
-  return startedAtRef;
-};
-
-const useSessionLifecycle = (start: (userId: string) => Promise<void>) => {
-  useEffect(() => {
-    void start('demo-user');
-  }, [start]);
-};
-
-const SessionRoutes = ({ importedLines, onImportLine, commandDispatcher }: SessionRoutesProps) => {
-  const session = useSessionState();
-  const { stats, currentCard, start, submitGrade } = session;
-  useSessionLifecycle(start);
-
-  const startedAtRef = useStartTimestamp(currentCard);
-
-  const overview = useMemo(() => buildOverview(stats), [stats]);
-  const dashboardOverview = useMemo(
-    () => augmentOverviewWithImports(overview, importedLines),
-    [overview, importedLines],
-  );
-  const canStartOpening = currentCard?.kind === 'Opening';
-  const openingCard = canStartOpening ? currentCard : undefined;
-
-  const handleGrade = (grade: ReviewGrade) => {
-    const latency = Math.max(0, Math.round(performance.now() - startedAtRef.current));
-    void submitGrade(grade, latency);
-  };
-
-  const handleBoardResult = (grade: ReviewGrade, latencyMs: number) => {
-    void submitGrade(grade, latencyMs);
-  };
-
-  return (
-    <Routes>
-      <Route path="/" element={<Navigate to="/dashboard" replace />} />
-      <Route
-        path="/dashboard"
-        element={
-          <DashboardPage
-            overview={dashboardOverview}
-            openingPath="/review/opening"
-            canStartOpening={canStartOpening}
-            onImportLine={onImportLine}
-            commandDispatcher={commandDispatcher}
-          />
-        }
-      />
-      <Route
-        path="/review/opening"
-        element={
-          <OpeningReviewPage
-            card={openingCard}
-            onGrade={handleGrade}
-            onBoardResult={handleBoardResult}
-            backPath="/dashboard"
-          />
-        }
-      />
-      <Route path="/tools/board" element={<BlankBoardPage />} />
-      <Route path="*" element={<Navigate to="/dashboard" replace />} />
-    </Routes>
-  );
-};
+import { createOpeningLineScheduler, linesMatch } from './utils/importedLines';
 
 const isTextEntryTarget = (target: EventTarget | null): boolean => {
   if (!(target instanceof HTMLElement)) {
     return false;
   }
 
-  const tagName = target.tagName;
   if (target.isContentEditable) {
     return true;
   }
 
+  const tagName = target.tagName;
   return tagName === 'INPUT' || tagName === 'TEXTAREA' || target.getAttribute('role') === 'textbox';
 };
 
@@ -181,6 +32,15 @@ const App = (): JSX.Element => {
   const [isConsoleOpen, setIsConsoleOpen] = useState(false);
   const [importedLines, setImportedLines] = useState<ScheduledOpeningLine[]>([]);
   const navigate = useNavigate();
+
+  const handleOpenConsole = useCallback(() => {
+    setIsConsoleOpen(true);
+  }, []);
+
+  const handleCloseConsole = useCallback(() => {
+    setIsConsoleOpen(false);
+  }, []);
+
   const dispatcher: CommandDispatcher = useMemo(() => {
     const buildNavigationHandler = (path: string): CommandHandler => {
       return () => {
@@ -194,21 +54,14 @@ const App = (): JSX.Element => {
         window.alert(input);
       },
       commands: [
-        {
-          command: 'cb',
-          handler: buildNavigationHandler('/tools/board'),
-        },
-        {
-          command: 's',
-          handler: buildNavigationHandler('/review/opening'),
-        },
-        {
-          command: 'db',
-          handler: buildNavigationHandler('/dashboard'),
-        },
+        { command: 'cb', handler: buildNavigationHandler('/tools/board') },
+        { command: 's', handler: buildNavigationHandler('/review/opening') },
+        { command: 'db', handler: buildNavigationHandler('/dashboard') },
       ],
     });
   }, [navigate]);
+
+  const scheduleOpeningLine = useMemo(() => createOpeningLineScheduler(), []);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -220,15 +73,13 @@ const App = (): JSX.Element => {
         }
 
         event.preventDefault();
-        setIsConsoleOpen(true);
+        handleOpenConsole();
         return;
       }
 
-      if (event.key === 'Escape') {
-        if (isConsoleOpen) {
-          event.preventDefault();
-          setIsConsoleOpen(false);
-        }
+      if (event.key === 'Escape' && isConsoleOpen) {
+        event.preventDefault();
+        handleCloseConsole();
       }
     };
 
@@ -236,25 +87,27 @@ const App = (): JSX.Element => {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isConsoleOpen]);
+  }, [handleCloseConsole, handleOpenConsole, isConsoleOpen]);
 
-  const handleImportLine = (line: DetectedOpeningLine): ImportResult => {
-    const existing = importedLines.find((candidate) => linesMatch(candidate, line));
-    if (existing) {
-      return { added: false, line: existing };
-    }
+  const handleImportLine = useCallback(
+    (line: DetectedOpeningLine): ImportResult => {
+      let importResult: ImportResult | undefined;
+      setImportedLines((previous) => {
+        const existing = previous.find((candidate) => linesMatch(candidate, line));
+        if (existing) {
+          importResult = { added: false, line: existing };
+          return previous;
+        }
 
-    const nextLine = scheduleOpeningLine(line, importedLines.length);
-    setImportedLines((previous) => [...previous, nextLine]);
-    return { added: true, line: nextLine };
-  };
+        const nextLine = scheduleOpeningLine(line, previous.length);
+        importResult = { added: true, line: nextLine };
+        return [...previous, nextLine];
+      });
 
-  const handleOpenConsole = () => {
-    setIsConsoleOpen(true);
-  };
-  const handleCloseConsole = () => {
-    setIsConsoleOpen(false);
-  };
+      return importResult as ImportResult;
+    },
+    [scheduleOpeningLine],
+  );
 
   const handleExecuteCommand = useCallback(
     async (input: string) => {

--- a/web-ui/src/components/SessionRoutes.tsx
+++ b/web-ui/src/components/SessionRoutes.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { JSX } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { useSyncExternalStore } from 'react';
+
+import { sampleSnapshot } from '../fixtures/sampleSnapshot';
+import { BlankBoardPage } from '../pages/BlankBoardPage';
+import { DashboardPage } from '../pages/DashboardPage';
+import { OpeningReviewPage } from '../pages/OpeningReviewPage';
+import { ReviewPlanner } from '../services/ReviewPlanner';
+import type { ReviewOverview } from '../services/ReviewPlanner';
+import type { CardSummary, ReviewGrade } from '../types/gateway';
+import type { DetectedOpeningLine, ImportResult, ScheduledOpeningLine } from '../types/repertoire';
+import { sessionStore } from '../state/sessionStore';
+import { composeOverview, extendOverviewWithImports } from '../utils/dashboardOverview';
+import type { CommandDispatcher } from '../utils/commandDispatcher';
+
+const planner = new ReviewPlanner();
+const baselineOverview = planner.buildOverview(sampleSnapshot);
+
+const useSessionState = () =>
+  useSyncExternalStore(sessionStore.subscribe, sessionStore.getState, sessionStore.getState);
+
+const useStartTimestamp = (card?: CardSummary) => {
+  const startedAtRef = useRef<number>(performance.now());
+  useEffect(() => {
+    if (card) {
+      startedAtRef.current = performance.now();
+    }
+  }, [card]);
+  return startedAtRef;
+};
+
+const useSessionLifecycle = (start: (userId: string) => Promise<void>) => {
+  useEffect(() => {
+    void start('demo-user');
+  }, [start]);
+};
+
+type SessionRoutesProps = {
+  importedLines: ScheduledOpeningLine[];
+  onImportLine: (line: DetectedOpeningLine) => ImportResult;
+  commandDispatcher?: CommandDispatcher;
+};
+
+const enhanceOverview = (
+  stats: ReturnType<typeof sessionStore.getState>['stats'],
+  importedLines: ScheduledOpeningLine[],
+): ReviewOverview => {
+  const overview = composeOverview(baselineOverview, stats);
+  return extendOverviewWithImports(overview, importedLines);
+};
+
+export const SessionRoutes = ({ importedLines, onImportLine, commandDispatcher }: SessionRoutesProps): JSX.Element => {
+  const session = useSessionState();
+  const { stats, currentCard, start, submitGrade } = session;
+  useSessionLifecycle(start);
+
+  const startedAtRef = useStartTimestamp(currentCard);
+  const overview = useMemo(() => enhanceOverview(stats, importedLines), [stats, importedLines]);
+  const canStartOpening = currentCard?.kind === 'Opening';
+  const openingCard = canStartOpening ? currentCard : undefined;
+
+  const handleGrade = (grade: ReviewGrade) => {
+    const latency = Math.max(0, Math.round(performance.now() - startedAtRef.current));
+    void submitGrade(grade, latency);
+  };
+
+  const handleBoardResult = (grade: ReviewGrade, latencyMs: number) => {
+    void submitGrade(grade, latencyMs);
+  };
+
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/dashboard" replace />} />
+      <Route
+        path="/dashboard"
+        element={
+          <DashboardPage
+            overview={overview}
+            openingPath="/review/opening"
+            canStartOpening={canStartOpening}
+            onImportLine={onImportLine}
+            commandDispatcher={commandDispatcher}
+          />
+        }
+      />
+      <Route
+        path="/review/opening"
+        element={
+          <OpeningReviewPage
+            card={openingCard}
+            onGrade={handleGrade}
+            onBoardResult={handleBoardResult}
+            backPath="/dashboard"
+          />
+        }
+      />
+      <Route path="/tools/board" element={<BlankBoardPage />} />
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
+  );
+};
+
+export type { SessionRoutesProps };

--- a/web-ui/src/utils/__tests__/dashboardOverview.test.ts
+++ b/web-ui/src/utils/__tests__/dashboardOverview.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ReviewOverview } from '../../services/ReviewPlanner';
+import type { SessionStats } from '../../types/gateway';
+import type { ScheduledOpeningLine } from '../../types/repertoire';
+
+import { composeOverview, extendOverviewWithImports } from '../dashboardOverview';
+
+describe('dashboardOverview', () => {
+  const baselineOverview: ReviewOverview = {
+    progress: {
+      totalDue: 18,
+      remaining: 9,
+      completedToday: 9,
+      completionRate: 0.5,
+      accuracyRate: 0.8,
+    },
+    tension: {
+      backlogPressure: 'low',
+      accuracyRisk: 'stable',
+    },
+    recommendation: {
+      primaryAction: 'Keep momentum',
+      secondaryAction: 'Focus on accuracy',
+    },
+    upcomingUnlocks: [],
+  };
+
+  it('falls back to the baseline when stats are undefined', () => {
+    const overview = composeOverview(baselineOverview, undefined);
+    expect(overview).toEqual(baselineOverview);
+  });
+
+  it('derives remaining count and completion rate from stats', () => {
+    const stats: SessionStats = {
+      reviews_today: 4,
+      accuracy: 0.5,
+      avg_latency_ms: 1234,
+      due_count: 6,
+      completed_count: 4,
+    };
+
+    const overview = composeOverview(baselineOverview, stats);
+
+    expect(overview.progress).toEqual({
+      totalDue: 6,
+      completedToday: 4,
+      remaining: 2,
+      completionRate: 2 / 3,
+      accuracyRate: 0.5,
+    });
+  });
+
+  it('treats a zero due count as complete', () => {
+    const stats: SessionStats = {
+      reviews_today: 0,
+      accuracy: 0.9,
+      avg_latency_ms: 1000,
+      due_count: 0,
+      completed_count: 0,
+    };
+
+    const overview = composeOverview(baselineOverview, stats);
+
+    expect(overview.progress).toMatchObject({
+      totalDue: 0,
+      completedToday: 0,
+      remaining: 0,
+      completionRate: 1,
+      accuracyRate: 0.9,
+    });
+  });
+
+  it('appends imported lines to the upcoming unlocks', () => {
+    const overview = composeOverview(baselineOverview, undefined);
+    const imports: ScheduledOpeningLine[] = [
+      {
+        id: 'import-1',
+        opening: 'Italian Game',
+        color: 'White',
+        moves: ['e4', 'e5', 'Nf3'],
+        display: '1.e4 e5 2.Nf3',
+        scheduledFor: '2024-04-01',
+      },
+    ];
+
+    const augmented = extendOverviewWithImports(overview, imports);
+
+    expect(augmented.upcomingUnlocks).toEqual([
+      {
+        id: 'import-1',
+        move: 'Italian Game (White)',
+        idea: 'Line: 1.e4 e5 2.Nf3',
+        scheduledFor: '2024-04-01',
+      },
+    ]);
+  });
+});

--- a/web-ui/src/utils/__tests__/importedLines.test.ts
+++ b/web-ui/src/utils/__tests__/importedLines.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DetectedOpeningLine } from '../../types/repertoire';
+
+import { createOpeningLineScheduler, linesMatch } from '../importedLines';
+
+describe('importedLines utilities', () => {
+  const line: DetectedOpeningLine = {
+    opening: "King's Gambit",
+    color: 'White',
+    moves: ['e4', 'e5', 'f4'],
+    display: '1.e4 e5 2.f4',
+  };
+
+  it('schedules opening lines with sequential offsets', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-03-01T00:00:00Z');
+    vi.setSystemTime(now);
+
+    const scheduler = createOpeningLineScheduler();
+
+    const first = scheduler(line, 0);
+    const second = scheduler(line, 1);
+
+    expect(first.scheduledFor).toBe('2024-03-02');
+    expect(second.scheduledFor).toBe('2024-03-03');
+    expect(first.id).not.toBe(second.id);
+    expect(first.moves).toEqual(line.moves);
+
+    vi.useRealTimers();
+  });
+
+  it('compares scheduled and detected lines for equality', () => {
+    const scheduler = createOpeningLineScheduler();
+    const scheduled = scheduler(line, 2);
+
+    expect(linesMatch(scheduled, line)).toBe(true);
+    expect(
+      linesMatch(
+        {
+          ...scheduled,
+          moves: [...scheduled.moves.slice(0, -1), 'Nc6'],
+        },
+        line,
+      ),
+    ).toBe(false);
+  });
+
+  it('detects when openings differ', () => {
+    const scheduler = createOpeningLineScheduler();
+    const scheduled = scheduler(line, 0);
+
+    expect(
+      linesMatch(
+        {
+          ...scheduled,
+          opening: 'Vienna Game',
+        },
+        line,
+      ),
+    ).toBe(false);
+  });
+
+  it('detects when move counts differ', () => {
+    const scheduler = createOpeningLineScheduler();
+    const scheduled = scheduler(line, 0);
+
+    expect(
+      linesMatch(
+        {
+          ...scheduled,
+          moves: scheduled.moves.slice(0, -1),
+        },
+        line,
+      ),
+    ).toBe(false);
+  });
+});

--- a/web-ui/src/utils/dashboardOverview.ts
+++ b/web-ui/src/utils/dashboardOverview.ts
@@ -1,0 +1,56 @@
+import type { ReviewOverview } from '../services/ReviewPlanner';
+import type { SessionStats } from '../types/gateway';
+import type { ScheduledOpeningLine } from '../types/repertoire';
+
+const deriveProgress = (
+  baseline: ReviewOverview['progress'],
+  stats?: SessionStats,
+): ReviewOverview['progress'] => {
+  if (!stats) {
+    return baseline;
+  }
+
+  const totalDue = stats.due_count;
+  const completed = stats.completed_count;
+  const remaining = Math.max(totalDue - completed, 0);
+  const completionRate = totalDue === 0 ? 1 : completed / totalDue;
+
+  return {
+    ...baseline,
+    totalDue,
+    completedToday: completed,
+    remaining,
+    completionRate,
+    accuracyRate: stats.accuracy,
+  };
+};
+
+export const composeOverview = (
+  baseline: ReviewOverview,
+  stats: SessionStats | undefined,
+): ReviewOverview => ({
+  ...baseline,
+  progress: deriveProgress(baseline.progress, stats),
+});
+
+export const extendOverviewWithImports = (
+  overview: ReviewOverview,
+  lines: ScheduledOpeningLine[],
+): ReviewOverview => {
+  if (lines.length === 0) {
+    return overview;
+  }
+
+  return {
+    ...overview,
+    upcomingUnlocks: [
+      ...overview.upcomingUnlocks,
+      ...lines.map((line) => ({
+        id: line.id,
+        move: `${line.opening} (${line.color})`,
+        idea: `Line: ${line.display}`,
+        scheduledFor: line.scheduledFor,
+      })),
+    ],
+  };
+};

--- a/web-ui/src/utils/importedLines.ts
+++ b/web-ui/src/utils/importedLines.ts
@@ -1,0 +1,38 @@
+import type { DetectedOpeningLine, ScheduledOpeningLine } from '../types/repertoire';
+
+type Clock = () => Date;
+
+type OpeningLineScheduler = (line: DetectedOpeningLine, offset: number) => ScheduledOpeningLine;
+
+const scheduleDate = (baseDate: Date, offset: number): string => {
+  const nextDate = new Date(baseDate);
+  nextDate.setDate(nextDate.getDate() + 1 + offset);
+  return nextDate.toISOString().slice(0, 10);
+};
+
+export const createOpeningLineScheduler = (clock: Clock = () => new Date()): OpeningLineScheduler => {
+  return (line, offset) => {
+    const baseDate = clock();
+    const scheduledFor = scheduleDate(baseDate, offset);
+    return {
+      ...line,
+      id: ['import', baseDate.getTime().toString(), offset.toString()].join('-'),
+      scheduledFor,
+    };
+  };
+};
+
+export const linesMatch = (
+  candidate: ScheduledOpeningLine,
+  target: DetectedOpeningLine,
+): boolean => {
+  if (candidate.opening !== target.opening || candidate.color !== target.color) {
+    return false;
+  }
+
+  if (candidate.moves.length !== target.moves.length) {
+    return false;
+  }
+
+  return candidate.moves.every((move, index) => move.toLowerCase() === target.moves[index]?.toLowerCase());
+};


### PR DESCRIPTION
## Summary
- extract the session routing logic into a dedicated SessionRoutes component and supporting overview utilities
- simplify App to focus on command console orchestration and imported line handling
- add targeted unit tests for dashboard overview composition and imported line scheduling helpers

## Testing
- npm run lint
- npm run typecheck
- npm run build
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68ea82cdb27c832592c125a8980ba647