### PR TITLE
Add wasm scheduler scaffolding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,8 +437,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -770,6 +782,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduler-wasm"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "console_error_panic_hook",
+ "getrandom 0.2.16",
+ "scheduler-core",
+ "serde",
+ "serde-wasm-bindgen",
+ "uuid",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +803,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/scheduler-wasm/Cargo.toml
+++ b/crates/scheduler-wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "scheduler-wasm"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+chrono = "0.4"
+console_error_panic_hook = "0.1"
+getrandom = { version = "0.2", features = ["js"] }
+scheduler-core = { path = "../scheduler-core" }
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+uuid = { version = "1", features = ["v4"] }
+wasm-bindgen = "0.2"

--- a/crates/scheduler-wasm/src/bindings.rs
+++ b/crates/scheduler-wasm/src/bindings.rs
@@ -1,0 +1,73 @@
+use std::convert::TryFrom;
+
+use chrono::NaiveDate;
+use scheduler_core::SchedulerConfig;
+use serde_wasm_bindgen::{from_value, to_value};
+use uuid::Uuid;
+use wasm_bindgen::prelude::*;
+
+use crate::config::{SchedulerConfigDto, SchedulerConfigPatch};
+use crate::scheduler::SchedulerFacade;
+
+/// Scheduler bindings exposed to JavaScript via wasm-bindgen.
+#[wasm_bindgen]
+pub struct WasmScheduler {
+    facade: SchedulerFacade,
+}
+
+#[wasm_bindgen]
+impl WasmScheduler {
+    /// Constructs a scheduler using the supplied configuration override.
+    #[wasm_bindgen(constructor)]
+    pub fn new(config: Option<JsValue>) -> Result<WasmScheduler, JsValue> {
+        let config = match config {
+            Some(value) => {
+                let patch: SchedulerConfigPatch =
+                    from_value(value).map_err(|err| JsValue::from_str(&err.to_string()))?;
+                Ok(patch.apply(SchedulerConfig::default()))
+            }
+            None => Ok(SchedulerConfig::default()),
+        }?;
+        Ok(Self {
+            facade: SchedulerFacade::new(config),
+        })
+    }
+
+    /// Returns the active scheduler configuration.
+    #[wasm_bindgen(js_name = "currentConfig")]
+    pub fn current_config(&self) -> Result<JsValue, JsValue> {
+        to_value(&SchedulerConfigDto::from(self.facade.config()))
+            .map_err(|err| JsValue::from_str(&err.to_string()))
+    }
+
+    /// Builds the queue for the provided owner and reports the number of cards.
+    #[wasm_bindgen(js_name = "buildQueueLength")]
+    pub fn build_queue_length(&mut self, owner_id: &str, iso_date: &str) -> Result<u32, JsValue> {
+        let owner_id = parse_owner_id(owner_id)?;
+        let today = parse_iso_date(iso_date)?;
+        let length = self.facade.queue_length(owner_id, today);
+        u32::try_from(length).map_err(|_| JsValue::from_str("queue length exceeds u32"))
+    }
+}
+
+/// Provides the default scheduler configuration for bootstrapping the wasm module.
+#[wasm_bindgen(js_name = "defaultConfig")]
+pub fn default_config() -> Result<JsValue, JsValue> {
+    to_value(&SchedulerConfigDto::from(&SchedulerConfig::default()))
+        .map_err(|err| JsValue::from_str(&err.to_string()))
+}
+
+/// Installs the console panic hook so Rust panics surface in the developer console.
+#[wasm_bindgen(js_name = "initPanicHook")]
+pub fn init_panic_hook() {
+    console_error_panic_hook::set_once();
+}
+
+fn parse_owner_id(value: &str) -> Result<Uuid, JsValue> {
+    Uuid::parse_str(value).map_err(|err| JsValue::from_str(&format!("invalid owner id: {err}")))
+}
+
+fn parse_iso_date(value: &str) -> Result<NaiveDate, JsValue> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|err| JsValue::from_str(&format!("invalid ISO date: {err}")))
+}

--- a/crates/scheduler-wasm/src/config.rs
+++ b/crates/scheduler-wasm/src/config.rs
@@ -1,0 +1,91 @@
+use scheduler_core::SchedulerConfig;
+use serde::{Deserialize, Serialize};
+
+/// Serializable snapshot of the scheduler configuration exposed to JavaScript consumers.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SchedulerConfigDto {
+    pub initial_ease_factor: f32,
+    pub ease_minimum: f32,
+    pub ease_maximum: f32,
+    pub learning_steps_minutes: Vec<u32>,
+}
+
+impl From<&SchedulerConfig> for SchedulerConfigDto {
+    fn from(config: &SchedulerConfig) -> Self {
+        Self {
+            initial_ease_factor: config.initial_ease_factor,
+            ease_minimum: config.ease_minimum,
+            ease_maximum: config.ease_maximum,
+            learning_steps_minutes: config.learning_steps_minutes.clone(),
+        }
+    }
+}
+
+/// Partial configuration update supplied from JavaScript.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct SchedulerConfigPatch {
+    pub initial_ease_factor: Option<f32>,
+    pub ease_minimum: Option<f32>,
+    pub ease_maximum: Option<f32>,
+    pub learning_steps_minutes: Option<Vec<u32>>,
+}
+
+impl SchedulerConfigPatch {
+    /// Applies the patch values to the provided configuration baseline.
+    #[must_use]
+    pub fn apply(self, mut base: SchedulerConfig) -> SchedulerConfig {
+        if let Some(initial_ease_factor) = self.initial_ease_factor {
+            base.initial_ease_factor = initial_ease_factor;
+        }
+        if let Some(ease_minimum) = self.ease_minimum {
+            base.ease_minimum = ease_minimum;
+        }
+        if let Some(ease_maximum) = self.ease_maximum {
+            base.ease_maximum = ease_maximum;
+        }
+        if let Some(learning_steps_minutes) = self.learning_steps_minutes {
+            base.learning_steps_minutes = learning_steps_minutes;
+        }
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn baseline() -> SchedulerConfig {
+        SchedulerConfig {
+            initial_ease_factor: 2.5,
+            ease_minimum: 1.3,
+            ease_maximum: 2.8,
+            learning_steps_minutes: vec![1, 10],
+        }
+    }
+
+    #[test]
+    fn dto_reflects_configuration_values() {
+        let config = baseline();
+        let dto = SchedulerConfigDto::from(&config);
+        assert_eq!(dto.initial_ease_factor, config.initial_ease_factor);
+        assert_eq!(dto.ease_minimum, config.ease_minimum);
+        assert_eq!(dto.ease_maximum, config.ease_maximum);
+        assert_eq!(dto.learning_steps_minutes, config.learning_steps_minutes);
+    }
+
+    #[test]
+    fn patch_overrides_selected_fields() {
+        let patch = SchedulerConfigPatch {
+            initial_ease_factor: Some(2.8),
+            ease_minimum: None,
+            ease_maximum: Some(3.0),
+            learning_steps_minutes: Some(vec![1, 5, 10]),
+        };
+        let patched = patch.apply(baseline());
+        assert_eq!(patched.initial_ease_factor, 2.8);
+        assert_eq!(patched.ease_minimum, 1.3);
+        assert_eq!(patched.ease_maximum, 3.0);
+        assert_eq!(patched.learning_steps_minutes, vec![1, 5, 10]);
+    }
+}

--- a/crates/scheduler-wasm/src/lib.rs
+++ b/crates/scheduler-wasm/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod config;
+pub mod scheduler;
+
+#[cfg(target_arch = "wasm32")]
+mod bindings;
+
+pub use config::{SchedulerConfigDto, SchedulerConfigPatch};
+pub use scheduler::SchedulerFacade;

--- a/crates/scheduler-wasm/src/scheduler.rs
+++ b/crates/scheduler-wasm/src/scheduler.rs
@@ -1,0 +1,51 @@
+use chrono::NaiveDate;
+use scheduler_core::{InMemoryStore, Scheduler, SchedulerConfig};
+use uuid::Uuid;
+
+/// Core scheduler wrapper shared between Rust unit tests and the wasm bindings.
+pub struct SchedulerFacade {
+    inner: Scheduler<InMemoryStore>,
+    config: SchedulerConfig,
+}
+
+impl SchedulerFacade {
+    /// Construct a scheduler facade backed by a fresh in-memory store.
+    #[must_use]
+    pub fn new(config: SchedulerConfig) -> Self {
+        let config_clone = config.clone();
+        let inner = Scheduler::new(InMemoryStore::new(), config);
+        Self {
+            inner,
+            config: config_clone,
+        }
+    }
+
+    /// Returns the configuration used by the facade.
+    #[must_use]
+    pub fn config(&self) -> &SchedulerConfig {
+        &self.config
+    }
+
+    /// Builds the queue for the supplied owner and returns its length.
+    #[must_use]
+    pub fn queue_length(&mut self, owner_id: Uuid, today: NaiveDate) -> usize {
+        self.inner.build_queue(owner_id, today).len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn naive_date(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("valid test date")
+    }
+
+    #[test]
+    fn queue_length_is_zero_without_cards() {
+        let mut facade = SchedulerFacade::new(SchedulerConfig::default());
+        let owner_id = Uuid::nil();
+        let today = naive_date(2024, 1, 1);
+        assert_eq!(facade.queue_length(owner_id, today), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a new scheduler-wasm crate with wasm-bindgen bindings around the scheduler facade
- expose configuration DTO/patch helpers and a reusable scheduler facade to drive future browser integrations

## Testing
- cargo test -p scheduler-wasm

------
https://chatgpt.com/codex/tasks/task_e_68ea83b9ccf08325a1915b9cdf51ef8f