### PR TITLE
Use GPT issue key for CI issue creation

### DIFF
--- a/.github/actions/run-with-error-logging/action.yml
+++ b/.github/actions/run-with-error-logging/action.yml
@@ -49,7 +49,9 @@ runs:
           cp "$tmp_log" "$dest"
           echo "Saved CI error log to $dest"
 
-          if [ -n "$GITHUB_TOKEN" ] && [ -n "$GITHUB_REPOSITORY" ]; then
+          issue_token="${GPT_ISSUE_KEY:-$GITHUB_TOKEN}"
+
+          if [ -n "$issue_token" ] && [ -n "$GITHUB_REPOSITORY" ]; then
             issue_title="CI failure: $label ($timestamp)"
             issue_api_url="https://api.github.com/repos/$GITHUB_REPOSITORY/issues"
 
@@ -100,7 +102,7 @@ PY
               # Capture stderr separately to provide detailed error messages
               curl_stderr=$(mktemp)
               response=$(curl -sS -X POST \
-                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Authorization: Bearer $issue_token" \
                 -H "Accept: application/vnd.github+json" \
                 -H "Content-Type: application/json" \
                 "$issue_api_url" \
@@ -138,7 +140,7 @@ PY
               echo "::warning::Failed to build GitHub issue payload for CI failure."
             fi
           else
-            echo "::warning::Skipping GitHub issue creation; missing GITHUB_TOKEN or GITHUB_REPOSITORY."
+            echo "::warning::Skipping GitHub issue creation; missing GPT_ISSUE_KEY/GITHUB_TOKEN or GITHUB_REPOSITORY."
           fi
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
   CARGO_INCREMENTAL: '0'
+  GPT_ISSUE_KEY: ${{ secrets.GPT_ISSUE_KEY }}
 
 jobs:
   rust:


### PR DESCRIPTION
## Summary
- use the GPT_ISSUE_KEY secret when creating CI failure issues
- update the CI workflow to expose the secret to composite steps

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ea937ff5c48325828afded7ca8ea50