### PR TITLE
Add comprehensive tests for Card struct

### DIFF
--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -12,3 +12,101 @@ pub struct Card<Id, Owner, Kind, State> {
     /// Mutable state associated with the card.
     pub state: State,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Card;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Owner(u64);
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum CardKind {
+        Tactics,
+        Strategy,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct CardState {
+        ease: f32,
+        interval_days: u32,
+        lapses: u32,
+    }
+
+    impl CardState {
+        fn new(ease: f32, interval_days: u32, lapses: u32) -> Self {
+            Self {
+                ease,
+                interval_days,
+                lapses,
+            }
+        }
+    }
+
+    #[test]
+    fn card_fields_are_stored() {
+        let card = Card {
+            id: "card-123".to_string(),
+            owner_id: Owner(42),
+            kind: CardKind::Tactics,
+            state: CardState::new(2.3, 7, 0),
+        };
+
+        assert_eq!(card.id, "card-123");
+        assert_eq!(card.owner_id, Owner(42));
+        assert_eq!(card.kind, CardKind::Tactics);
+        assert_eq!(card.state, CardState::new(2.3, 7, 0));
+    }
+
+    #[test]
+    fn cards_with_identical_fields_are_equal() {
+        let card_a = Card {
+            id: 1_u32,
+            owner_id: Owner(3),
+            kind: CardKind::Strategy,
+            state: CardState::new(1.7, 3, 1),
+        };
+        let card_b = Card {
+            id: 1_u32,
+            owner_id: Owner(3),
+            kind: CardKind::Strategy,
+            state: CardState::new(1.7, 3, 1),
+        };
+
+        assert_eq!(card_a, card_b);
+    }
+
+    #[test]
+    fn card_clone_produces_distinct_but_equal_instance() {
+        let original = Card {
+            id: [0_u8; 16],
+            owner_id: Owner(7),
+            kind: CardKind::Tactics,
+            state: CardState::new(2.1, 14, 2),
+        };
+
+        let clone = original.clone();
+
+        assert_eq!(original, clone);
+        assert!(std::ptr::eq(&original, &original));
+        assert!(!std::ptr::eq(&original, &clone));
+    }
+
+    #[test]
+    fn card_allows_mutating_state_through_public_field() {
+        let mut card = Card {
+            id: 9_i64,
+            owner_id: Owner(100),
+            kind: CardKind::Strategy,
+            state: CardState::new(2.5, 10, 0),
+        };
+
+        card.state.ease = 2.8;
+        card.state.interval_days += 5;
+        card.state.lapses += 1;
+
+        assert_eq!(card.state.ease, 2.8);
+        assert_eq!(card.state.interval_days, 15);
+        assert_eq!(card.state.lapses, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused test module for the generic `Card` type
- cover field storage, equality semantics, cloning, and mutability behavior

## Testing
- cargo test -p review-domain

------
https://chatgpt.com/codex/tasks/task_e_68eba6df3558832587a427920cd33316