### PR TITLE
Add floating corner button component

### DIFF
--- a/web-ui/src/components/FloatingCornerButton.css
+++ b/web-ui/src/components/FloatingCornerButton.css
@@ -1,0 +1,59 @@
+.floating-corner-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 9999px;
+  border: none;
+  font-weight: 600;
+  line-height: 1;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(245, 247, 255, 0.98));
+  color: #1b1f3b;
+  box-shadow:
+    0 0 0 1px rgba(27, 31, 59, 0.05),
+    0 8px 16px rgba(27, 31, 59, 0.18);
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease,
+    filter 160ms ease;
+}
+
+.floating-corner-button:hover,
+.floating-corner-button:focus-visible {
+  transform: translate(50%, -60%);
+  box-shadow:
+    0 0 0 1px rgba(27, 31, 59, 0.08),
+    0 12px 24px rgba(27, 31, 59, 0.28);
+  filter: brightness(1.02);
+}
+
+.floating-corner-button:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(82, 110, 255, 0.3),
+    0 0 0 1px rgba(27, 31, 59, 0.1),
+    0 12px 24px rgba(27, 31, 59, 0.28);
+}
+
+.floating-corner-button:active {
+  transform: translate(50%, -45%);
+  box-shadow:
+    0 0 0 1px rgba(27, 31, 59, 0.1),
+    0 6px 14px rgba(27, 31, 59, 0.2);
+}
+
+.floating-corner-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow:
+    0 0 0 1px rgba(27, 31, 59, 0.05),
+    0 4px 8px rgba(27, 31, 59, 0.12);
+}

--- a/web-ui/src/components/FloatingCornerButton.tsx
+++ b/web-ui/src/components/FloatingCornerButton.tsx
@@ -1,0 +1,20 @@
+import { forwardRef } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
+
+import './FloatingCornerButton.css';
+
+export type FloatingCornerButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const FloatingCornerButton = forwardRef<HTMLButtonElement, FloatingCornerButtonProps>(
+  ({ className, type = 'button', ...buttonProps }, ref) => {
+    const combinedClassName = ['floating-corner-button', className]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <button {...buttonProps} className={combinedClassName} ref={ref} type={type} />
+    );
+  },
+);
+
+FloatingCornerButton.displayName = 'FloatingCornerButton';

--- a/web-ui/src/components/__tests__/FloatingCornerButton.test.tsx
+++ b/web-ui/src/components/__tests__/FloatingCornerButton.test.tsx
@@ -1,0 +1,47 @@
+import { createRef } from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FloatingCornerButton } from '../FloatingCornerButton';
+
+describe('FloatingCornerButton', () => {
+  it('renders children inside the button and keeps it clickable', () => {
+    const onClick = vi.fn();
+
+    render(
+      <FloatingCornerButton onClick={onClick}>
+        <span data-testid="content">Action</span>
+      </FloatingCornerButton>,
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('floating-corner-button');
+
+    const content = screen.getByTestId('content');
+    expect(content).toHaveTextContent('Action');
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards refs to the underlying button element and merges class names', () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    const { container } = render(
+      <FloatingCornerButton ref={ref} className="test-class">
+        Focus
+      </FloatingCornerButton>,
+    );
+
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+    if (!button) {
+      throw new Error('Expected a button element');
+    }
+
+    expect(ref.current).toBe(button);
+    expect(button).toHaveAttribute('type', 'button');
+    expect(button.className.split(' ')).toContain('test-class');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable floating corner button component for overlay actions
- style the button to offset from the top-right corner with hover, focus, and disabled states
- cover the component with tests for rendering, click handling, and ref forwarding

## Testing
- npm run test -- FloatingCornerButton

------
https://chatgpt.com/codex/tasks/task_e_68ebb226090483258576490fefdffa08