### PR TITLE
Add implementation plan documentation for reusable chessboard

### DIFF
--- a/docs/chessboard_implementation_plan.md
+++ b/docs/chessboard_implementation_plan.md
@@ -1,0 +1,32 @@
+# Reusable Chessboard Implementation Plan
+
+## Objectives
+- Extract a reusable chessboard UI component that can be shared across multiple application contexts (e.g., openings, tactics).
+- Provide configuration options (colors, orientation, coordinates display, interaction hooks) to support diverse use cases.
+- Encapsulate chessboard-specific state management to minimize duplication and simplify future enhancements.
+- Ensure comprehensive automated test coverage so that `make test` continues to pass.
+
+## Architectural Approach
+1. **Component Extraction**
+   - Identify existing chessboard-related UI elements and consolidate them into a new base component (e.g., `BaseChessboard`).
+   - Define a clear public API for rendering, configuration, and event callbacks.
+2. **State Management**
+   - Implement internal state handling for board positions, selected squares, highlighting, and move history as needed.
+   - Expose controlled props to allow consumers to override or synchronize state when required.
+3. **Styling & Theming**
+   - Support customizable colors, square sizes, and optional overlays through props or a theming system.
+   - Ensure responsive design considerations so the chessboard adapts to various layouts.
+4. **Extensibility Strategy**
+   - Allow feature-specific components (e.g., `TacticsChessboard`, `OpeningsChessboard`) to compose the base component with additional logic.
+   - Document extension points and recommended patterns for specialization.
+
+## Testing Strategy
+- Add unit tests covering rendering, configuration options, state transitions, and event handling.
+- Include snapshot or visual regression tests if available to guard against unintended UI changes.
+- Update or add integration tests to validate interactions in contexts where the chessboard is used.
+- Run `make test` to verify the workspace passes with the new component and tests.
+
+## Documentation & Adoption
+- Provide usage examples and guidelines for configuring the base chessboard component.
+- Outline migration steps for existing code to adopt the new component.
+- Communicate testing expectations and how to extend the component safely.


### PR DESCRIPTION
## Summary
- add documentation describing the objectives, architecture, testing, and adoption plan for a reusable chessboard component

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ebb3365600832596f3d031a9b4a889