### PR TITLE
Scaffold application layer contracts for the web UI

### DIFF
--- a/web-ui/src/application/__tests__/application-contracts.spec.ts
+++ b/web-ui/src/application/__tests__/application-contracts.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, expectTypeOf } from 'vitest';
+import {
+  applicationControllers,
+  applicationServices,
+  applicationViewModels,
+} from '../index.js';
+import type {
+  CommandPaletteService,
+  DashboardViewModel,
+  ImportPlanner,
+  OpeningReviewController,
+  PgnImportService,
+  SessionController,
+} from '../index.js';
+
+describe('application layer scaffolding', () => {
+  it('exposes planned service contracts', () => {
+    expect(applicationServices).toBeDefined();
+    expect(Object.keys(applicationServices)).toEqual(
+      expect.arrayContaining(['pgnImport', 'commandPalette', 'importPlanner']),
+    );
+    expectTypeOf<PgnImportService>().toBeObject();
+    expectTypeOf<CommandPaletteService>().toBeObject();
+    expectTypeOf<ImportPlanner>().toBeObject();
+  });
+
+  it('exposes planned controller contracts', () => {
+    expect(applicationControllers).toBeDefined();
+    expect(Object.keys(applicationControllers)).toEqual(
+      expect.arrayContaining(['openingReview', 'session']),
+    );
+    expectTypeOf<OpeningReviewController>().toBeObject();
+    expectTypeOf<SessionController>().toBeObject();
+  });
+
+  it('exposes planned view model contracts', () => {
+    expect(applicationViewModels).toBeDefined();
+    expect(Object.keys(applicationViewModels)).toEqual(
+      expect.arrayContaining(['dashboard']),
+    );
+    expectTypeOf<DashboardViewModel>().toBeObject();
+  });
+});

--- a/web-ui/src/application/controllers/OpeningReviewController.ts
+++ b/web-ui/src/application/controllers/OpeningReviewController.ts
@@ -1,0 +1,42 @@
+import type { ReviewGrade } from '../../types/gateway';
+
+export type ReviewMove = {
+  san: string;
+  uci: string;
+  from: string;
+  to: string;
+};
+
+export type OpeningReviewStatus =
+  | 'idle'
+  | 'preparing'
+  | 'awaitingMove'
+  | 'evaluating'
+  | 'completed'
+  | 'error';
+
+export type OpeningReviewSnapshot = {
+  status: OpeningReviewStatus;
+  activeLineId?: string;
+  boardFen: string;
+  lastMove?: ReviewMove;
+  expectedMoves: ReviewMove[];
+  attemptedMoves: ReviewMove[];
+  latencyMs?: number;
+  error?: string;
+};
+
+export type OpeningReviewEvent =
+  | { type: 'move'; move: ReviewMove }
+  | { type: 'status'; status: OpeningReviewStatus }
+  | { type: 'error'; message: string };
+
+export interface OpeningReviewController {
+  getSnapshot(): OpeningReviewSnapshot;
+  selectSquare(square: string): void;
+  dropPiece(from: string, to: string): void;
+  submitGrade(grade: ReviewGrade): Promise<void>;
+  loadLine(lineId: string): Promise<void>;
+  reset(): void;
+  subscribe(listener: (snapshot: OpeningReviewSnapshot, event?: OpeningReviewEvent) => void): () => void;
+}

--- a/web-ui/src/application/controllers/SessionController.ts
+++ b/web-ui/src/application/controllers/SessionController.ts
@@ -1,0 +1,33 @@
+import type {
+  CardSummary,
+  ReviewGrade,
+  SessionStats,
+} from '../../types/gateway';
+
+export type SessionStatus =
+  | 'idle'
+  | 'loading'
+  | 'active'
+  | 'submittingGrade'
+  | 'completed'
+  | 'error';
+
+export type SessionSnapshot = {
+  status: SessionStatus;
+  sessionId?: string;
+  currentCard?: CardSummary;
+  queueSize: number;
+  stats?: SessionStats;
+  lastGrade?: ReviewGrade;
+  error?: string;
+};
+
+export interface SessionController {
+  getSnapshot(): SessionSnapshot;
+  subscribe(listener: (snapshot: SessionSnapshot) => void): () => void;
+  start(): Promise<void>;
+  startDemo(): Promise<void>;
+  submitGrade(grade: ReviewGrade, latencyMs: number): Promise<void>;
+  preloadNext(): Promise<void>;
+  reset(): void;
+}

--- a/web-ui/src/application/index.ts
+++ b/web-ui/src/application/index.ts
@@ -1,0 +1,27 @@
+export * from './services/PgnImportService.js';
+export * from './services/CommandPaletteService.js';
+export * from './services/ImportPlanner.js';
+export * from './controllers/OpeningReviewController.js';
+export * from './controllers/SessionController.js';
+export * from './viewModels/DashboardViewModel.js';
+
+export const applicationServices = {
+  pgnImport: Symbol.for('application:PgnImportService'),
+  commandPalette: Symbol.for('application:CommandPaletteService'),
+  importPlanner: Symbol.for('application:ImportPlanner'),
+} as const;
+
+export type ApplicationServiceTokens = typeof applicationServices;
+
+export const applicationControllers = {
+  openingReview: Symbol.for('application:OpeningReviewController'),
+  session: Symbol.for('application:SessionController'),
+} as const;
+
+export type ApplicationControllerTokens = typeof applicationControllers;
+
+export const applicationViewModels = {
+  dashboard: Symbol.for('application:DashboardViewModel'),
+} as const;
+
+export type ApplicationViewModelTokens = typeof applicationViewModels;

--- a/web-ui/src/application/services/CommandPaletteService.ts
+++ b/web-ui/src/application/services/CommandPaletteService.ts
@@ -1,0 +1,32 @@
+export type CommandContext = {
+  source: 'palette' | 'shortcut' | 'api';
+  issuedAt: Date;
+};
+
+export type CommandRegistration = {
+  id: string;
+  title: string;
+  keywords?: string[];
+  category?: string;
+  description?: string;
+};
+
+export type CommandExecution = {
+  command: CommandRegistration;
+  context: CommandContext;
+  status: 'success' | 'error';
+  message?: string;
+};
+
+export type CommandHandler = (
+  context: CommandContext,
+) => Promise<CommandExecution | void> | CommandExecution | void;
+
+export interface CommandPaletteService {
+  register(command: CommandRegistration, handler: CommandHandler): void;
+  unregister(commandId: string): void;
+  list(): CommandRegistration[];
+  execute(commandId: string, context?: Partial<CommandContext>): Promise<CommandExecution>;
+  subscribe(listener: (execution: CommandExecution) => void): () => void;
+  reset(): void;
+}

--- a/web-ui/src/application/services/ImportPlanner.ts
+++ b/web-ui/src/application/services/ImportPlanner.ts
@@ -1,0 +1,16 @@
+import type {
+  DetectedOpeningLine,
+  ScheduledOpeningLine,
+} from '../../types/repertoire';
+
+export type ImportPlan = {
+  line: ScheduledOpeningLine;
+  createdAt: Date;
+  messages: string[];
+};
+
+export interface ImportPlanner {
+  planLine(line: DetectedOpeningLine, referenceDate?: Date): ImportPlan;
+  planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[];
+  persist(plan: ImportPlan): Promise<void>;
+}

--- a/web-ui/src/application/services/PgnImportService.ts
+++ b/web-ui/src/application/services/PgnImportService.ts
@@ -1,0 +1,35 @@
+import type {
+  DetectedOpeningLine,
+  ScheduledOpeningLine,
+} from '../../types/repertoire';
+
+export type PgnImportSource = {
+  kind: 'text' | 'file';
+  value: string | File | Blob;
+};
+
+export type PgnImportPreview = {
+  normalizedPgn: string;
+  detectedLines: DetectedOpeningLine[];
+  scheduledLines: ScheduledOpeningLine[];
+};
+
+export type PgnImportFeedbackMessage = {
+  id: string;
+  tone: 'success' | 'info' | 'warning' | 'danger';
+  headline: string;
+  body?: string;
+  dispatchAt: Date;
+};
+
+export type PgnImportOutcome = {
+  preview: PgnImportPreview;
+  messages: PgnImportFeedbackMessage[];
+  errors: string[];
+};
+
+export interface PgnImportService {
+  detect(source: PgnImportSource): Promise<PgnImportOutcome>;
+  acknowledge(outcome: PgnImportOutcome): void;
+  clear(): void;
+}

--- a/web-ui/src/application/viewModels/DashboardViewModel.ts
+++ b/web-ui/src/application/viewModels/DashboardViewModel.ts
@@ -1,0 +1,38 @@
+import type { SessionStats } from '../../types/gateway';
+import type { ImportResult, ScheduledOpeningLine } from '../../types/repertoire';
+
+export type DashboardMetric = {
+  id: string;
+  label: string;
+  value: string;
+  helperText?: string;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
+};
+
+export type DashboardBadge = {
+  id: string;
+  tone: 'success' | 'info' | 'warning' | 'danger';
+  title: string;
+  description?: string;
+};
+
+export type UpcomingUnlock = {
+  line: ScheduledOpeningLine;
+  friendlyDate: string;
+};
+
+export type DashboardOverview = {
+  metrics: DashboardMetric[];
+  badge: DashboardBadge | null;
+  upcomingUnlocks: UpcomingUnlock[];
+  importResults: ImportResult[];
+  stats: SessionStats | null;
+};
+
+export interface DashboardViewModel {
+  load(): Promise<DashboardOverview>;
+  refresh(): Promise<DashboardOverview>;
+  subscribe(listener: (overview: DashboardOverview) => void): () => void;
+  applyImportResults(results: ImportResult[]): void;
+  updateSessionStats(stats: SessionStats): void;
+}


### PR DESCRIPTION
## Summary
- add an application layer directory structure with exports for services, controllers, and view models described in the UI separation plan
- define contract interfaces for PGN import, command palette, import planning, opening review, session coordination, and dashboard data modeling
- cover the new scaffolding with a Vitest suite that asserts the aggregated contracts are exposed to the UI layer

## Testing
- npm run test --prefix web-ui
- make test *(fails: clippy `borrow_as_ptr` / `float_cmp` lint errors in crates/review-domain)*

------
https://chatgpt.com/codex/tasks/task_e_68ebbe5c6c5c8325a1c101e7a53c2a80