### PR TITLE
Document application-layer scaffolding details

### DIFF
--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -21,7 +21,7 @@ The following three workstreams capture all existing plans while clarifying sequ
 **Goals:** Extract orchestration logic from React, deliver reusable components (including the chessboard), and expose testable contracts.
 
 **Key Milestones:**
-1. Establish `application/` layer scaffolding with services/controllers/view models as outlined in the separation plan.【F:docs/ui-separation-plan.md†L39-L94】
+1. ✅ Establish `application/` layer scaffolding with services/controllers/view models as outlined in the separation plan. The scaffolding now ships symbol tokens and TypeScript contract definitions under `web-ui/src/application/`, giving follow-on work a stable import surface.【F:docs/ui-separation-plan.md†L39-L129】【F:web-ui/src/application/index.ts†L1-L26】
 2. Execute UI refactor roadmap checklists, starting with PGN import and dashboard view models for quick wins, then session controller and command palette hooks.【F:docs/ui-component-refactor-roadmap.md†L63-L168】
 3. Deliver the reusable chessboard base component with configuration API and documentation, integrating it into the new controllers/hooks.【F:docs/chessboard_implementation_plan.md†L1-L33】
 4. Update UI tests to cover hooks/services headlessly and components via snapshots as prescribed across the UI plans.【F:docs/chessboard_implementation_plan.md†L22-L29】【F:docs/ui-component-refactor-roadmap.md†L19-L26】

--- a/docs/ui-separation-plan.md
+++ b/docs/ui-separation-plan.md
@@ -44,6 +44,29 @@ Backend APIs ──> Gateway clients ──> Application Layer (new) ──> Rea
 | `CommandPaletteService` | Registers navigation/utility commands, exposes `execute`, and emits results or errors. | `CommandConsole`, `App` |
 | `ImportPlanner` | Determines schedule dates and IDs for new repertoire lines and persists them via backend APIs when available. | `SessionController`, `DashboardViewModel` |
 
+### Contract surface snapshot (May 2024)
+
+The scaffolding introduced in `web-ui/src/application/` formalizes each contract with concrete method signatures so the UI can
+depend on a stable surface area during migration:
+
+- **Service tokens:** `applicationServices`, `applicationControllers`, and `applicationViewModels` export symbol maps so React
+  adapters can resolve dependencies without importing individual files.【F:web-ui/src/application/index.ts†L1-L26】
+- **`PgnImportService`:** declares `detect`, `acknowledge`, and `clear` to manage the PGN import lifecycle and the feedback
+  messages emitted after an import attempt.【F:web-ui/src/application/services/PgnImportService.ts†L24-L29】
+- **`CommandPaletteService`:** includes `register`, `unregister`, `list`, `execute`, `subscribe`, and `reset` so palette
+  integrations can manage commands reactively and observe execution results.【F:web-ui/src/application/services/CommandPaletteService.ts†L18-L29】
+- **`ImportPlanner`:** provides `planLine`, `planBulk`, and `persist` so the UI can request deterministic schedules before any
+  persistence side effects occur.【F:web-ui/src/application/services/ImportPlanner.ts†L12-L15】
+- **`OpeningReviewController`:** exposes `getSnapshot`, `selectSquare`, `dropPiece`, `submitGrade`, `loadLine`, `reset`, and
+  `subscribe` so board widgets can react to state transitions without owning chess logic.【F:web-ui/src/application/controllers/OpeningReviewController.ts†L24-L39】
+- **`SessionController`:** surfaces `getSnapshot`, `subscribe`, `start`, `startDemo`, `submitGrade`, `preloadNext`, and `reset`
+  so routes can react to gateway updates without manually orchestrating queues.【F:web-ui/src/application/controllers/SessionController.ts†L22-L34】
+- **`DashboardViewModel`:** centralizes `load`, `refresh`, `subscribe`, `applyImportResults`, and `updateSessionStats` to
+  deliver ready-to-render dashboard payloads for React components.【F:web-ui/src/application/viewModels/DashboardViewModel.ts†L28-L36】
+
+Future updates to this document should replace these placeholder descriptions with links to the concrete implementations once
+they graduate from scaffolding to production logic.
+
 ## Migration Plan
 1. **Define application layer structure**
    * Create `web-ui/src/application/` with subfolders for `services/`, `controllers/`, and `viewModels/`.

--- a/web-ui/src/application/__tests__/application-contracts.spec.ts
+++ b/web-ui/src/application/__tests__/application-contracts.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, expectTypeOf } from 'vitest';
+import {
+  applicationControllers,
+  applicationServices,
+  applicationViewModels,
+} from '../index.js';
+import type {
+  CommandPaletteService,
+  DashboardViewModel,
+  ImportPlanner,
+  OpeningReviewController,
+  PgnImportService,
+  SessionController,
+} from '../index.js';
+
+describe('application layer scaffolding', () => {
+  it('exposes planned service contracts', () => {
+    expect(applicationServices).toBeDefined();
+    expect(Object.keys(applicationServices)).toEqual(
+      expect.arrayContaining(['pgnImport', 'commandPalette', 'importPlanner']),
+    );
+    expectTypeOf<PgnImportService>().toBeObject();
+    expectTypeOf<CommandPaletteService>().toBeObject();
+    expectTypeOf<ImportPlanner>().toBeObject();
+  });
+
+  it('exposes planned controller contracts', () => {
+    expect(applicationControllers).toBeDefined();
+    expect(Object.keys(applicationControllers)).toEqual(
+      expect.arrayContaining(['openingReview', 'session']),
+    );
+    expectTypeOf<OpeningReviewController>().toBeObject();
+    expectTypeOf<SessionController>().toBeObject();
+  });
+
+  it('exposes planned view model contracts', () => {
+    expect(applicationViewModels).toBeDefined();
+    expect(Object.keys(applicationViewModels)).toEqual(
+      expect.arrayContaining(['dashboard']),
+    );
+    expectTypeOf<DashboardViewModel>().toBeObject();
+  });
+});

--- a/web-ui/src/application/controllers/OpeningReviewController.ts
+++ b/web-ui/src/application/controllers/OpeningReviewController.ts
@@ -1,0 +1,42 @@
+import type { ReviewGrade } from '../../types/gateway';
+
+export type ReviewMove = {
+  san: string;
+  uci: string;
+  from: string;
+  to: string;
+};
+
+export type OpeningReviewStatus =
+  | 'idle'
+  | 'preparing'
+  | 'awaitingMove'
+  | 'evaluating'
+  | 'completed'
+  | 'error';
+
+export type OpeningReviewSnapshot = {
+  status: OpeningReviewStatus;
+  activeLineId?: string;
+  boardFen: string;
+  lastMove?: ReviewMove;
+  expectedMoves: ReviewMove[];
+  attemptedMoves: ReviewMove[];
+  latencyMs?: number;
+  error?: string;
+};
+
+export type OpeningReviewEvent =
+  | { type: 'move'; move: ReviewMove }
+  | { type: 'status'; status: OpeningReviewStatus }
+  | { type: 'error'; message: string };
+
+export interface OpeningReviewController {
+  getSnapshot(): OpeningReviewSnapshot;
+  selectSquare(square: string): void;
+  dropPiece(from: string, to: string): void;
+  submitGrade(grade: ReviewGrade): Promise<void>;
+  loadLine(lineId: string): Promise<void>;
+  reset(): void;
+  subscribe(listener: (snapshot: OpeningReviewSnapshot, event?: OpeningReviewEvent) => void): () => void;
+}

--- a/web-ui/src/application/controllers/SessionController.ts
+++ b/web-ui/src/application/controllers/SessionController.ts
@@ -1,0 +1,33 @@
+import type {
+  CardSummary,
+  ReviewGrade,
+  SessionStats,
+} from '../../types/gateway';
+
+export type SessionStatus =
+  | 'idle'
+  | 'loading'
+  | 'active'
+  | 'submittingGrade'
+  | 'completed'
+  | 'error';
+
+export type SessionSnapshot = {
+  status: SessionStatus;
+  sessionId?: string;
+  currentCard?: CardSummary;
+  queueSize: number;
+  stats?: SessionStats;
+  lastGrade?: ReviewGrade;
+  error?: string;
+};
+
+export interface SessionController {
+  getSnapshot(): SessionSnapshot;
+  subscribe(listener: (snapshot: SessionSnapshot) => void): () => void;
+  start(): Promise<void>;
+  startDemo(): Promise<void>;
+  submitGrade(grade: ReviewGrade, latencyMs: number): Promise<void>;
+  preloadNext(): Promise<void>;
+  reset(): void;
+}

--- a/web-ui/src/application/index.ts
+++ b/web-ui/src/application/index.ts
@@ -1,0 +1,27 @@
+export * from './services/PgnImportService.js';
+export * from './services/CommandPaletteService.js';
+export * from './services/ImportPlanner.js';
+export * from './controllers/OpeningReviewController.js';
+export * from './controllers/SessionController.js';
+export * from './viewModels/DashboardViewModel.js';
+
+export const applicationServices = {
+  pgnImport: Symbol.for('application:PgnImportService'),
+  commandPalette: Symbol.for('application:CommandPaletteService'),
+  importPlanner: Symbol.for('application:ImportPlanner'),
+} as const;
+
+export type ApplicationServiceTokens = typeof applicationServices;
+
+export const applicationControllers = {
+  openingReview: Symbol.for('application:OpeningReviewController'),
+  session: Symbol.for('application:SessionController'),
+} as const;
+
+export type ApplicationControllerTokens = typeof applicationControllers;
+
+export const applicationViewModels = {
+  dashboard: Symbol.for('application:DashboardViewModel'),
+} as const;
+
+export type ApplicationViewModelTokens = typeof applicationViewModels;

--- a/web-ui/src/application/services/CommandPaletteService.ts
+++ b/web-ui/src/application/services/CommandPaletteService.ts
@@ -1,0 +1,32 @@
+export type CommandContext = {
+  source: 'palette' | 'shortcut' | 'api';
+  issuedAt: Date;
+};
+
+export type CommandRegistration = {
+  id: string;
+  title: string;
+  keywords?: string[];
+  category?: string;
+  description?: string;
+};
+
+export type CommandExecution = {
+  command: CommandRegistration;
+  context: CommandContext;
+  status: 'success' | 'error';
+  message?: string;
+};
+
+export type CommandHandler = (
+  context: CommandContext,
+) => Promise<CommandExecution | void> | CommandExecution | void;
+
+export interface CommandPaletteService {
+  register(command: CommandRegistration, handler: CommandHandler): void;
+  unregister(commandId: string): void;
+  list(): CommandRegistration[];
+  execute(commandId: string, context?: Partial<CommandContext>): Promise<CommandExecution>;
+  subscribe(listener: (execution: CommandExecution) => void): () => void;
+  reset(): void;
+}

--- a/web-ui/src/application/services/ImportPlanner.ts
+++ b/web-ui/src/application/services/ImportPlanner.ts
@@ -1,0 +1,16 @@
+import type {
+  DetectedOpeningLine,
+  ScheduledOpeningLine,
+} from '../../types/repertoire';
+
+export type ImportPlan = {
+  line: ScheduledOpeningLine;
+  createdAt: Date;
+  messages: string[];
+};
+
+export interface ImportPlanner {
+  planLine(line: DetectedOpeningLine, referenceDate?: Date): ImportPlan;
+  planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[];
+  persist(plan: ImportPlan): Promise<void>;
+}

--- a/web-ui/src/application/services/PgnImportService.ts
+++ b/web-ui/src/application/services/PgnImportService.ts
@@ -1,0 +1,35 @@
+import type {
+  DetectedOpeningLine,
+  ScheduledOpeningLine,
+} from '../../types/repertoire';
+
+export type PgnImportSource = {
+  kind: 'text' | 'file';
+  value: string | File | Blob;
+};
+
+export type PgnImportPreview = {
+  normalizedPgn: string;
+  detectedLines: DetectedOpeningLine[];
+  scheduledLines: ScheduledOpeningLine[];
+};
+
+export type PgnImportFeedbackMessage = {
+  id: string;
+  tone: 'success' | 'info' | 'warning' | 'danger';
+  headline: string;
+  body?: string;
+  dispatchAt: Date;
+};
+
+export type PgnImportOutcome = {
+  preview: PgnImportPreview;
+  messages: PgnImportFeedbackMessage[];
+  errors: string[];
+};
+
+export interface PgnImportService {
+  detect(source: PgnImportSource): Promise<PgnImportOutcome>;
+  acknowledge(outcome: PgnImportOutcome): void;
+  clear(): void;
+}

--- a/web-ui/src/application/viewModels/DashboardViewModel.ts
+++ b/web-ui/src/application/viewModels/DashboardViewModel.ts
@@ -1,0 +1,38 @@
+import type { SessionStats } from '../../types/gateway';
+import type { ImportResult, ScheduledOpeningLine } from '../../types/repertoire';
+
+export type DashboardMetric = {
+  id: string;
+  label: string;
+  value: string;
+  helperText?: string;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
+};
+
+export type DashboardBadge = {
+  id: string;
+  tone: 'success' | 'info' | 'warning' | 'danger';
+  title: string;
+  description?: string;
+};
+
+export type UpcomingUnlock = {
+  line: ScheduledOpeningLine;
+  friendlyDate: string;
+};
+
+export type DashboardOverview = {
+  metrics: DashboardMetric[];
+  badge: DashboardBadge | null;
+  upcomingUnlocks: UpcomingUnlock[];
+  importResults: ImportResult[];
+  stats: SessionStats | null;
+};
+
+export interface DashboardViewModel {
+  load(): Promise<DashboardOverview>;
+  refresh(): Promise<DashboardOverview>;
+  subscribe(listener: (overview: DashboardOverview) => void): () => void;
+  applyImportResults(results: ImportResult[]): void;
+  updateSessionStats(stats: SessionStats): void;
+}


### PR DESCRIPTION
## Summary
- extend the UI separation plan with a contract surface snapshot that lists the new application-layer interfaces and token exports
- mark the application-layer scaffolding milestone as complete in the strategic roadmap and note the symbol maps under `web-ui/src/application`

## Testing
- npm run test --prefix web-ui
- make test *(fails: clippy pedantic `borrow_as_ptr` / `float_cmp` violations in crates/review-domain)*

------
https://chatgpt.com/codex/tasks/task_e_68ebbe5c6c5c8325a1c101e7a53c2a80