### PR TITLE
Implement ImportPlanner service for deterministic scheduling

### DIFF
--- a/web-ui/src/application/services/ImportPlanner.ts
+++ b/web-ui/src/application/services/ImportPlanner.ts
@@ -2,6 +2,7 @@ import type {
   DetectedOpeningLine,
   ScheduledOpeningLine,
 } from '../../types/repertoire';
+import { linesMatch } from '../../utils/importedLines.js';
 
 export type ImportPlan = {
   line: ScheduledOpeningLine;
@@ -14,3 +15,108 @@ export interface ImportPlanner {
   planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[];
   persist(plan: ImportPlan): Promise<void>;
 }
+
+type Clock = () => Date;
+type IdFactory = () => string;
+type PersistPlan = (plan: ImportPlan) => Promise<void> | void;
+
+export type ImportPlannerDependencies = {
+  clock?: Clock;
+  idFactory?: IdFactory;
+  persistPlan?: PersistPlan;
+  initialLines?: ScheduledOpeningLine[];
+};
+
+const cloneDate = (date: Date): Date => new Date(date.getTime());
+
+const scheduleDate = (baseDate: Date, offset: number): string => {
+  const scheduled = cloneDate(baseDate);
+  scheduled.setDate(scheduled.getDate() + 1 + offset);
+  return scheduled.toISOString().slice(0, 10);
+};
+
+const defaultIdFactory: IdFactory = () => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).slice(2);
+};
+
+const defaultPersist: PersistPlan = async () => {
+  // Intentionally left blank; consumers can supply a persistence adapter.
+};
+
+export const createImportPlanner = (
+  dependencies: ImportPlannerDependencies = {},
+): ImportPlanner => {
+  const {
+    clock = () => new Date(),
+    idFactory = defaultIdFactory,
+    persistPlan = defaultPersist,
+    initialLines = [],
+  } = dependencies;
+
+  const plannedLines: ScheduledOpeningLine[] = [...initialLines];
+
+  const resolveBaseDate = (referenceDate?: Date): Date => {
+    if (referenceDate) {
+      return cloneDate(referenceDate);
+    }
+
+    return cloneDate(clock());
+  };
+
+  const planLine = (
+    line: DetectedOpeningLine,
+    referenceDate?: Date,
+  ): ImportPlan => {
+    const baseDate = resolveBaseDate(referenceDate);
+    const existing = plannedLines.find((candidate) => linesMatch(candidate, line));
+
+    if (existing) {
+      return {
+        line: existing,
+        createdAt: cloneDate(baseDate),
+        messages: [`Line already scheduled for ${existing.scheduledFor}`],
+      };
+    }
+
+    const scheduledFor = scheduleDate(baseDate, plannedLines.length);
+    const scheduledLine: ScheduledOpeningLine = {
+      ...line,
+      id: idFactory(),
+      scheduledFor,
+    };
+
+    plannedLines.push(scheduledLine);
+
+    return {
+      line: scheduledLine,
+      createdAt: cloneDate(baseDate),
+      messages: [`Line scheduled for ${scheduledFor}`],
+    };
+  };
+
+  const planBulk = (
+    lines: DetectedOpeningLine[],
+    referenceDate?: Date,
+  ): ImportPlan[] => {
+    if (lines.length === 0) {
+      return [];
+    }
+
+    const baseDate = resolveBaseDate(referenceDate);
+    return lines.map((line) => planLine(line, baseDate));
+  };
+
+  const persist = async (plan: ImportPlan): Promise<void> => {
+    await persistPlan(plan);
+  };
+
+  return {
+    planLine,
+    planBulk,
+    persist,
+  };
+};

--- a/web-ui/src/application/services/__tests__/ImportPlanner.test.ts
+++ b/web-ui/src/application/services/__tests__/ImportPlanner.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { createImportPlanner } from '../ImportPlanner.js';
+import type { DetectedOpeningLine } from '../../../types/repertoire.js';
+
+const whiteItalian: DetectedOpeningLine = {
+  opening: 'Italian Game',
+  color: 'White',
+  moves: ['e4', 'e5', 'Nf3', 'Nc6', 'Bc4', 'Bc5'],
+  display: '1.e4 e5 2.Nf3 Nc6 3.Bc4 Bc5',
+};
+
+const blackSicilian: DetectedOpeningLine = {
+  opening: 'Sicilian Defence',
+  color: 'Black',
+  moves: ['e4', 'c5', 'Nf3', 'd6'],
+  display: '1.e4 c5 2.Nf3 d6',
+};
+
+describe('createImportPlanner', () => {
+  it('schedules new lines with deterministic ids and sequential dates', () => {
+    const ids = ['line-1', 'line-2'];
+    const planner = createImportPlanner({
+      clock: () => new Date('2024-03-10T00:00:00Z'),
+      idFactory: () => ids.shift() ?? 'unexpected-id',
+    });
+
+    const firstPlan = planner.planLine(whiteItalian);
+    expect(firstPlan.line.id).toBe('line-1');
+    expect(firstPlan.line.scheduledFor).toBe('2024-03-11');
+    expect(firstPlan.createdAt.toISOString()).toBe('2024-03-10T00:00:00.000Z');
+    expect(firstPlan.messages).toEqual(['Line scheduled for 2024-03-11']);
+
+    const secondPlan = planner.planLine(blackSicilian);
+    expect(secondPlan.line.id).toBe('line-2');
+    expect(secondPlan.line.scheduledFor).toBe('2024-03-12');
+    expect(secondPlan.messages).toEqual(['Line scheduled for 2024-03-12']);
+  });
+
+  it('deduplicates lines and reports the existing schedule', () => {
+    const planner = createImportPlanner({
+      clock: () => new Date('2024-04-01T00:00:00Z'),
+      idFactory: () => 'duplicate-id',
+    });
+
+    const firstPlan = planner.planLine(whiteItalian);
+    const duplicatePlan = planner.planLine({ ...whiteItalian });
+
+    expect(duplicatePlan.line).toBe(firstPlan.line);
+    expect(duplicatePlan.messages).toEqual([
+      `Line already scheduled for ${firstPlan.line.scheduledFor}`,
+    ]);
+    expect(duplicatePlan.createdAt.toISOString()).toBe('2024-04-01T00:00:00.000Z');
+  });
+
+  it('plans bulk imports against a shared reference date and persists through the adapter', async () => {
+    const persisted: string[] = [];
+    const planner = createImportPlanner({
+      clock: () => new Date('2024-01-01T00:00:00Z'),
+      idFactory: () => 'bulk-id',
+      persistPlan: async (plan) => {
+        persisted.push(`${plan.line.id}:${plan.line.scheduledFor}`);
+      },
+    });
+
+    const referenceDate = new Date('2024-05-05T09:00:00Z');
+    const [firstPlan, secondPlan] = planner.planBulk([
+      whiteItalian,
+      { ...whiteItalian, moves: ['e4', 'e5', 'Nf3', 'Nc6', 'Bc4', 'Bb5'] },
+    ], referenceDate);
+
+    expect(firstPlan.createdAt.toISOString()).toBe('2024-05-05T09:00:00.000Z');
+    expect(firstPlan.line.scheduledFor).toBe('2024-05-06');
+    expect(secondPlan.line.scheduledFor).toBe('2024-05-07');
+
+    await planner.persist(firstPlan);
+    await planner.persist(secondPlan);
+
+    expect(persisted).toEqual([
+      `${firstPlan.line.id}:${firstPlan.line.scheduledFor}`,
+      `${secondPlan.line.id}:${secondPlan.line.scheduledFor}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement an ImportPlanner service that deterministically schedules detected repertoire lines, deduplicates against existing plans, and supports pluggable persistence adapters
- add unit tests that document scheduling offsets, duplicate detection, and persistence delegation for the planner

## Testing
- npm run test --prefix web-ui

------
https://chatgpt.com/codex/tasks/task_e_68ebfe42e80c8325bb88a6ba755fbde1