### PR TITLE
Implement session controller with demo and live flows

### DIFF
--- a/web-ui/src/application/controllers/SessionController.ts
+++ b/web-ui/src/application/controllers/SessionController.ts
@@ -2,6 +2,7 @@ import type {
   CardSummary,
   ReviewGrade,
   SessionStats,
+  StartSessionResponse,
 } from '../../types/gateway';
 
 export type SessionStatus =
@@ -31,3 +32,244 @@ export interface SessionController {
   preloadNext(): Promise<void>;
   reset(): void;
 }
+
+type SessionGateway = {
+  startSession(userId: string): Promise<StartSessionResponse>;
+  grade(
+    cardId: string,
+    gradeValue: ReviewGrade,
+    latencyMs: number,
+  ): Promise<{ next_card?: CardSummary }>;
+  stats(): Promise<SessionStats>;
+};
+
+export type DemoSessionPlan = {
+  sessionId: string;
+  cards: CardSummary[];
+  stats: SessionStats;
+};
+
+export type SessionControllerDependencies = {
+  gateway: SessionGateway;
+  defaultUserId?: string;
+  demoSession?: DemoSessionPlan;
+  onError?: (error: unknown) => void;
+};
+
+export type SessionSnapshotListener = (snapshot: SessionSnapshot) => void;
+
+type ControllerMode = 'idle' | 'live' | 'demo';
+
+type SnapshotUpdater =
+  | Partial<SessionSnapshot>
+  | ((snapshot: SessionSnapshot) => SessionSnapshot);
+
+const serializeError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch (_jsonError) {
+    void _jsonError;
+  }
+
+  return 'Unknown session error';
+};
+
+const initialSnapshot = (): SessionSnapshot => ({
+  status: 'idle',
+  queueSize: 0,
+});
+
+const applySnapshot = (
+  snapshot: SessionSnapshot,
+  update: SnapshotUpdater,
+): SessionSnapshot => {
+  if (typeof update === 'function') {
+    return update(snapshot);
+  }
+
+  return { ...snapshot, ...update } satisfies SessionSnapshot;
+};
+
+export const createSessionController = ({
+  gateway,
+  defaultUserId,
+  demoSession,
+  onError,
+}: SessionControllerDependencies): SessionController => {
+  let snapshot = initialSnapshot();
+  let mode: ControllerMode = 'idle';
+  const listeners = new Set<SessionSnapshotListener>();
+  let liveQueueSize = 0;
+  let demoQueue: CardSummary[] = [];
+
+  const notify = (update: SnapshotUpdater) => {
+    snapshot = applySnapshot(snapshot, update);
+    listeners.forEach((listener) => listener(snapshot));
+  };
+
+  const fail = (error: unknown) => {
+    onError?.(error);
+    notify({ status: 'error', error: serializeError(error) });
+  };
+
+  const resetInternals = () => {
+    mode = 'idle';
+    liveQueueSize = 0;
+    demoQueue = [];
+    snapshot = initialSnapshot();
+  };
+
+  const startLive = async () => {
+    notify({ status: 'loading', error: undefined });
+
+    try {
+      const userId = defaultUserId ?? 'demo-user';
+      const [session, stats] = await Promise.all([
+        gateway.startSession(userId),
+        gateway.stats(),
+      ]);
+
+      mode = 'live';
+      liveQueueSize = Math.max(0, session.queue_size);
+      demoQueue = [];
+
+      notify({
+        status: 'active',
+        sessionId: session.session_id,
+        currentCard: session.first_card,
+        queueSize: liveQueueSize,
+        stats,
+        lastGrade: undefined,
+        error: undefined,
+      });
+    } catch (error) {
+      resetInternals();
+      fail(error);
+    }
+  };
+
+  const advanceDemo = (grade: ReviewGrade) => {
+    const nextCard = demoQueue.shift();
+    if (nextCard) {
+      notify({
+        status: 'active',
+        currentCard: nextCard,
+        queueSize: demoQueue.length + 1,
+        lastGrade: grade,
+        error: undefined,
+      });
+      return;
+    }
+
+    notify({
+      status: 'completed',
+      currentCard: undefined,
+      queueSize: 0,
+      lastGrade: grade,
+      error: undefined,
+    });
+  };
+
+  const advanceLive = async (
+    cardId: string,
+    grade: ReviewGrade,
+    latencyMs: number,
+  ) => {
+    try {
+      const gradeResult = await gateway.grade(cardId, grade, latencyMs);
+      const stats = await gateway.stats();
+
+      liveQueueSize = Math.max(0, liveQueueSize - 1);
+      const nextCard = gradeResult.next_card;
+
+      if (nextCard) {
+        liveQueueSize = Math.max(liveQueueSize, 1);
+        notify({
+          status: 'active',
+          currentCard: nextCard,
+          queueSize: liveQueueSize,
+          stats,
+          lastGrade: grade,
+          error: undefined,
+        });
+        return;
+      }
+
+      notify({
+        status: 'completed',
+        currentCard: undefined,
+        queueSize: 0,
+        stats,
+        lastGrade: grade,
+        error: undefined,
+      });
+    } catch (error) {
+      fail(error);
+    }
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    async start() {
+      await startLive();
+    },
+    async startDemo() {
+      if (!demoSession || demoSession.cards.length === 0) {
+        fail('Demo session is not available');
+        return;
+      }
+
+      mode = 'demo';
+      demoQueue = demoSession.cards.slice(1);
+      liveQueueSize = demoSession.cards.length;
+
+      notify({
+        status: 'active',
+        sessionId: demoSession.sessionId,
+        currentCard: demoSession.cards[0],
+        queueSize: liveQueueSize,
+        stats: demoSession.stats,
+        lastGrade: undefined,
+        error: undefined,
+      });
+    },
+    async submitGrade(grade, latencyMs) {
+      const activeCard = snapshot.currentCard;
+      if (!activeCard) {
+        return;
+      }
+
+      notify({ status: 'submittingGrade', lastGrade: grade, error: undefined });
+
+      if (mode === 'demo') {
+        advanceDemo(grade);
+        return;
+      }
+
+      await advanceLive(activeCard.card_id, grade, latencyMs);
+    },
+    async preloadNext() {
+      if (mode === 'demo') {
+        return;
+      }
+      // Placeholder for future queue preloading.
+    },
+    reset() {
+      resetInternals();
+    },
+  };
+};

--- a/web-ui/src/application/controllers/__tests__/SessionController.test.ts
+++ b/web-ui/src/application/controllers/__tests__/SessionController.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  CardSummary,
+  ReviewGrade,
+  SessionStats,
+  StartSessionResponse,
+} from '../../../types/gateway.js';
+import {
+  createSessionController,
+  type SessionSnapshot,
+} from '../SessionController.js';
+
+describe('createSessionController', () => {
+  const sampleCard: CardSummary = {
+    card_id: 'card-1',
+    kind: 'Opening',
+    position_fen: 'startpos',
+    prompt: 'Play e4',
+    expected_moves_uci: ['e2e4'],
+  };
+  const followUpCard: CardSummary = {
+    card_id: 'card-2',
+    kind: 'Tactic',
+    position_fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1',
+    prompt: 'Respond to e4',
+    expected_moves_uci: ['c7c5'],
+  };
+  const sampleStats: SessionStats = {
+    reviews_today: 3,
+    accuracy: 0.75,
+    avg_latency_ms: 1234,
+    due_count: 12,
+    completed_count: 8,
+  };
+
+  const gateway = {
+    startSession: vi.fn<[], Promise<StartSessionResponse>>(),
+    grade: vi.fn<
+      [string, ReviewGrade, number],
+      Promise<{ next_card?: CardSummary }>
+    >(),
+    stats: vi.fn<[], Promise<SessionStats>>(),
+  };
+
+  const buildController = () =>
+    createSessionController({
+      gateway,
+      defaultUserId: 'user-123',
+      demoSession: {
+        sessionId: 'demo-session',
+        cards: [sampleCard, followUpCard],
+        stats: sampleStats,
+      },
+    });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('starts idle with an empty queue', () => {
+    const controller = buildController();
+    expect(controller.getSnapshot()).toEqual<SessionSnapshot>({
+      status: 'idle',
+      queueSize: 0,
+    });
+  });
+
+  it('loads a live session from the gateway', async () => {
+    const controller = buildController();
+    gateway.startSession.mockResolvedValue({
+      session_id: 'session-99',
+      queue_size: 4,
+      first_card: sampleCard,
+    });
+    gateway.stats.mockResolvedValue(sampleStats);
+
+    const updates: SessionSnapshot[] = [];
+    controller.subscribe((snapshot) => {
+      updates.push(snapshot);
+    });
+
+    await controller.start();
+
+    expect(gateway.startSession).toHaveBeenCalledWith('user-123');
+    expect(updates.at(0)?.status).toBe('loading');
+    expect(updates.at(-1)).toMatchObject({
+      status: 'active',
+      sessionId: 'session-99',
+      currentCard: sampleCard,
+      queueSize: 4,
+      stats: sampleStats,
+      error: undefined,
+    });
+  });
+
+  it('submits a grade against the active card and refreshes stats', async () => {
+    const controller = buildController();
+    gateway.startSession.mockResolvedValue({
+      session_id: 'session-99',
+      queue_size: 2,
+      first_card: sampleCard,
+    });
+    gateway.stats.mockResolvedValue(sampleStats);
+    gateway.grade.mockResolvedValue({ next_card: followUpCard });
+
+    await controller.start();
+    await controller.submitGrade('Good', 987);
+
+    expect(gateway.grade).toHaveBeenCalledWith('card-1', 'Good', 987);
+    expect(gateway.stats).toHaveBeenCalledTimes(2);
+    expect(controller.getSnapshot()).toMatchObject({
+      status: 'active',
+      currentCard: followUpCard,
+      queueSize: 1,
+      lastGrade: 'Good',
+      stats: sampleStats,
+    });
+  });
+
+  it('supports demo sessions without talking to the gateway', async () => {
+    const controller = buildController();
+
+    await controller.startDemo();
+
+    expect(gateway.startSession).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      status: 'active',
+      sessionId: 'demo-session',
+      currentCard: sampleCard,
+      queueSize: 2,
+    });
+
+    await controller.submitGrade('Hard', 2500);
+
+    expect(gateway.grade).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toMatchObject({
+      status: 'active',
+      currentCard: followUpCard,
+      queueSize: 1,
+      lastGrade: 'Hard',
+    });
+  });
+
+  it('resets to an idle snapshot', async () => {
+    const controller = buildController();
+    gateway.startSession.mockResolvedValue({
+      session_id: 'session-99',
+      queue_size: 2,
+      first_card: sampleCard,
+    });
+    gateway.stats.mockResolvedValue(sampleStats);
+
+    await controller.start();
+    controller.reset();
+
+    expect(controller.getSnapshot()).toEqual({ status: 'idle', queueSize: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `createSessionController` with live gateway calls, demo session fallback, and robust snapshot handling
- add dedicated Vitest coverage for session controller behaviours across live, demo, and reset flows

## Testing
- npm run test --prefix web-ui

------
https://chatgpt.com/codex/tasks/task_e_68ebfe5854e4832591d05e4848f1479f