### PR TITLE
Implement import planner service

### DIFF
--- a/web-ui/src/application/index.ts
+++ b/web-ui/src/application/index.ts
@@ -1,6 +1,7 @@
 export * from './services/PgnImportService.js';
 export * from './services/CommandPaletteService.js';
 export * from './services/ImportPlanner.js';
+export * from './services/DefaultImportPlanner.js';
 export * from './controllers/OpeningReviewController.js';
 export * from './controllers/SessionController.js';
 export * from './viewModels/DashboardViewModel.js';

--- a/web-ui/src/application/services/DefaultImportPlanner.ts
+++ b/web-ui/src/application/services/DefaultImportPlanner.ts
@@ -1,0 +1,120 @@
+import type {
+  DetectedOpeningLine,
+  ScheduledOpeningLine,
+} from '../../types/repertoire';
+import type { ImportPlan, ImportPlanner } from './ImportPlanner';
+
+type Clock = () => Date;
+type GenerateId = () => string;
+type PersistSink = (plan: ImportPlan) => Promise<void> | void;
+
+type PlannerOptions = {
+  clock?: Clock;
+  generateId?: GenerateId;
+  initialLines?: ScheduledOpeningLine[];
+  persist?: PersistSink;
+};
+
+const defaultClock: Clock = () => new Date();
+const defaultGenerateId: GenerateId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).slice(2);
+};
+
+const signatureFor = (line: Pick<DetectedOpeningLine, 'opening' | 'color' | 'moves'>): string => {
+  const normalizedMoves = line.moves.map((move) => move.trim().toLowerCase()).join(' ');
+  return `${line.opening.toLowerCase()}|${line.color.toLowerCase()}|${normalizedMoves}`;
+};
+
+const scheduleDate = (base: Date, offset: number): string => {
+  const scheduled = new Date(base);
+  scheduled.setHours(0, 0, 0, 0);
+  scheduled.setDate(scheduled.getDate() + 1 + offset);
+  return scheduled.toISOString().slice(0, 10);
+};
+
+export class DefaultImportPlanner implements ImportPlanner {
+  private readonly clock: Clock;
+  private readonly generateId: GenerateId;
+  private readonly persistSink?: PersistSink;
+  private readonly persisted: Map<string, ScheduledOpeningLine> = new Map();
+  private readonly persistedOrder: string[] = [];
+  private readonly staged: Map<string, ScheduledOpeningLine> = new Map();
+  private stagedOrder: string[] = [];
+
+  constructor(options: PlannerOptions = {}) {
+    const { clock = defaultClock, generateId = defaultGenerateId, initialLines = [], persist } = options;
+    this.clock = clock;
+    this.generateId = generateId;
+    this.persistSink = persist;
+
+    for (const line of initialLines) {
+      this.storePersisted(line);
+    }
+  }
+
+  planLine(line: DetectedOpeningLine, referenceDate?: Date): ImportPlan {
+    const signature = signatureFor(line);
+    const existing = this.lookup(signature);
+    const createdAt = this.clock();
+
+    if (existing) {
+      return {
+        line: existing,
+        createdAt,
+        messages: [`Line already scheduled for ${existing.scheduledFor}`],
+      };
+    }
+
+    const baseDate = referenceDate ? new Date(referenceDate) : new Date(createdAt);
+    const offset = this.persistedOrder.length + this.stagedOrder.length;
+    const scheduledLine: ScheduledOpeningLine = {
+      ...line,
+      id: this.generateId(),
+      scheduledFor: scheduleDate(baseDate, offset),
+    };
+
+    this.staged.set(signature, scheduledLine);
+    this.stagedOrder = [...this.stagedOrder, signature];
+
+    return {
+      line: scheduledLine,
+      createdAt,
+      messages: [`Scheduled ${line.opening} (${line.color}) for ${scheduledLine.scheduledFor}`],
+    };
+  }
+
+  planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[] {
+    const baseDate = referenceDate ? new Date(referenceDate) : this.clock();
+    return lines.map((line) => this.planLine(line, baseDate));
+  }
+
+  async persist(plan: ImportPlan): Promise<void> {
+    if (this.persistSink) {
+      await this.persistSink(plan);
+    }
+
+    const signature = signatureFor(plan.line);
+    this.staged.delete(signature);
+    this.stagedOrder = this.stagedOrder.filter((value) => value !== signature);
+    this.storePersisted(plan.line);
+  }
+
+  private lookup(signature: string): ScheduledOpeningLine | undefined {
+    return this.staged.get(signature) ?? this.persisted.get(signature);
+  }
+
+  private storePersisted(line: ScheduledOpeningLine): void {
+    const signature = signatureFor(line);
+    if (this.persisted.has(signature)) {
+      this.persisted.set(signature, line);
+      return;
+    }
+
+    this.persisted.set(signature, line);
+    this.persistedOrder.push(signature);
+  }
+}

--- a/web-ui/src/application/services/__tests__/import-planner.spec.ts
+++ b/web-ui/src/application/services/__tests__/import-planner.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ImportPlan } from '../ImportPlanner.js';
+import type { DetectedOpeningLine, ScheduledOpeningLine } from '../../../types/repertoire.js';
+import { DefaultImportPlanner } from '../DefaultImportPlanner.js';
+
+const makeLine = (overrides: Partial<DetectedOpeningLine> = {}): DetectedOpeningLine => ({
+  opening: 'London System',
+  color: 'White',
+  moves: ['d4', 'Nf3', 'Bf4'],
+  display: '1.d4 Nf3 2.Bf4',
+  ...overrides,
+});
+
+type PlannerOptions = {
+  now?: Date | (() => Date);
+  ids?: string[];
+  existing?: ScheduledOpeningLine[];
+  persist?: (plan: ImportPlan) => Promise<void> | void;
+};
+
+const buildPlanner = (options: PlannerOptions = {}): DefaultImportPlanner => {
+  const { now, ids = ['id-1', 'id-2', 'id-3'], existing = [], persist } = options;
+  const clock = typeof now === 'function' ? now : () => new Date(now ?? '2024-01-01T00:00:00.000Z');
+  const idGenerator = vi.fn(() => {
+    const value = ids.shift();
+    if (!value) {
+      throw new Error('Exhausted test UUIDs');
+    }
+
+    return value;
+  });
+
+  return new DefaultImportPlanner({ clock, generateId: idGenerator, initialLines: existing, persist });
+};
+
+describe('DefaultImportPlanner', () => {
+  it('plans a single line for the day after the reference date', () => {
+    const planner = buildPlanner({ now: new Date('2024-04-10T12:00:00.000Z'), ids: ['scheduled-1'] });
+    const line = makeLine();
+
+    const plan = planner.planLine(line, new Date('2024-04-01T00:00:00.000Z'));
+
+    expect(plan.line).toEqual({
+      ...line,
+      id: 'scheduled-1',
+      scheduledFor: '2024-04-02',
+    });
+    expect(plan.createdAt.toISOString()).toBe('2024-04-10T12:00:00.000Z');
+    expect(plan.messages).toEqual([
+      'Scheduled London System (White) for 2024-04-02',
+    ]);
+  });
+
+  it('increments the scheduled date for each newly planned line before persisting', () => {
+    const planner = buildPlanner({ now: () => new Date('2024-04-10T12:00:00.000Z') });
+    const first = planner.planLine(makeLine({ opening: 'London System' }), new Date('2024-04-01T00:00:00.000Z'));
+    const second = planner.planLine(
+      makeLine({ opening: 'Jobava London', moves: ['d4', 'Nc3', 'Bf4'], display: '1.d4 Nc3 2.Bf4' }),
+      new Date('2024-04-01T00:00:00.000Z'),
+    );
+
+    expect(first.line.scheduledFor).toBe('2024-04-02');
+    expect(second.line.scheduledFor).toBe('2024-04-03');
+    expect(second.messages).toEqual([
+      'Scheduled Jobava London (White) for 2024-04-03',
+    ]);
+  });
+
+  it('returns the existing schedule when the line has already been persisted', () => {
+    const existingLine: ScheduledOpeningLine = {
+      ...makeLine(),
+      id: 'existing-1',
+      scheduledFor: '2024-04-05',
+    };
+    const planner = buildPlanner({ existing: [existingLine] });
+
+    const plan = planner.planLine(makeLine(), new Date('2024-04-01T00:00:00.000Z'));
+
+    expect(plan.line).toEqual(existingLine);
+    expect(plan.messages).toEqual([
+      'Line already scheduled for 2024-04-05',
+    ]);
+  });
+
+  it('persists new plans using the provided sink and tracks them as existing', async () => {
+    const save = vi.fn(async () => {});
+    const planner = buildPlanner({ now: new Date('2024-04-10T12:00:00.000Z'), persist: save });
+    const plan = planner.planLine(makeLine(), new Date('2024-04-01T00:00:00.000Z'));
+
+    await planner.persist(plan);
+
+    expect(save).toHaveBeenCalledWith(plan);
+
+    const duplicate = planner.planLine(makeLine(), new Date('2024-04-01T00:00:00.000Z'));
+    expect(duplicate.line).toEqual(plan.line);
+    expect(duplicate.messages).toEqual([
+      'Line already scheduled for 2024-04-02',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a DefaultImportPlanner service that deterministically schedules and deduplicates imported lines while supporting persistence hooks
- cover the planner with vitest unit tests for single imports, sequential planning, duplicate detection, and persistence handling
- re-export the planner from the application index for downstream consumers

## Testing
- npm run test --prefix web-ui

------
https://chatgpt.com/codex/tasks/task_e_68ebfe193b8c83259d8ac9b5860f38cd