### PR TITLE
Implement PGN import service and hook

### DIFF
--- a/web-ui/src/application/hooks/__tests__/usePgnImport.spec.tsx
+++ b/web-ui/src/application/hooks/__tests__/usePgnImport.spec.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CommandPaletteService } from '../../services/CommandPaletteService.js';
+import type { PgnImportOutcome, PgnImportService } from '../../services/PgnImportService.js';
+import { usePgnImport } from '../usePgnImport.js';
+
+const sampleOutcome: PgnImportOutcome = {
+  preview: {
+    normalizedPgn: '1.e4 e5 2.Nf3 Nc6',
+    detectedLines: [
+      {
+        opening: "King's Knight Opening",
+        color: 'White',
+        moves: ['e4', 'e5', 'Nf3', 'Nc6'],
+        display: '1.e4 e5 2.Nf3 Nc6',
+      },
+    ],
+    scheduledLines: [
+      {
+        opening: "King's Knight Opening",
+        color: 'White',
+        moves: ['e4', 'e5', 'Nf3', 'Nc6'],
+        display: '1.e4 e5 2.Nf3 Nc6',
+        id: 'line-1',
+        scheduledFor: '2024-01-05',
+      },
+    ],
+  },
+  messages: [
+    {
+      id: 'message-1',
+      tone: 'success',
+      headline: 'Scheduled for 2024-01-05 in your white repertoire.',
+      dispatchAt: new Date('2024-01-02T00:00:00Z'),
+    },
+  ],
+  errors: [],
+};
+
+const createService = (overrides: Partial<PgnImportService> = {}): PgnImportService => ({
+  detect: vi.fn().mockResolvedValue(sampleOutcome),
+  acknowledge: vi.fn(),
+  clear: vi.fn(),
+  ...overrides,
+});
+
+const createCommandPalette = (): CommandPaletteService => ({
+  register: vi.fn(),
+  unregister: vi.fn(),
+  list: vi.fn(),
+  execute: vi.fn(),
+  subscribe: vi.fn(),
+  reset: vi.fn(),
+});
+
+describe('usePgnImport', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('detects openings from text input and exposes the preview state', async () => {
+    const service = createService();
+    const { result } = renderHook(() => usePgnImport({ service }));
+
+    act(() => {
+      result.current.actions.activate('paste');
+    });
+
+    await act(async () => {
+      await result.current.actions.setSourceText('1.e4 e5 2.Nf3 Nc6');
+    });
+
+    expect(service.detect).toHaveBeenCalledWith({ kind: 'text', value: '1.e4 e5 2.Nf3 Nc6' });
+    expect(result.current.state.preview).toEqual(sampleOutcome.preview);
+    expect(result.current.state.messages).toEqual(sampleOutcome.messages);
+    expect(result.current.state.errors).toEqual([]);
+  });
+
+  it('acknowledges feedback messages and clears them from state', async () => {
+    const service = createService();
+    const { result } = renderHook(() => usePgnImport({ service }));
+
+    act(() => {
+      result.current.actions.activate('paste');
+    });
+
+    await act(async () => {
+      await result.current.actions.setSourceText('1.e4 e5 2.Nf3 Nc6');
+    });
+
+    act(() => {
+      result.current.actions.acknowledgeMessages();
+    });
+
+    expect(service.acknowledge).toHaveBeenCalledWith(sampleOutcome);
+    expect(result.current.state.messages).toEqual([]);
+  });
+
+  it('registers a collapse command with the command palette', async () => {
+    const service = createService();
+    const commandPalette = createCommandPalette();
+
+    const { result, unmount } = renderHook(() => usePgnImport({ service, commandPalette }));
+
+    expect(commandPalette.register).toHaveBeenCalledTimes(1);
+    const [registration, handler] = commandPalette.register.mock.calls[0];
+    expect(registration.id).toBe('pgn-import:collapse');
+
+    act(() => {
+      result.current.actions.activate('paste');
+    });
+
+    await act(async () => {
+      await result.current.actions.setSourceText('1.e4 e5 2.Nf3 Nc6');
+    });
+
+    await act(async () => {
+      await handler({ source: 'palette', issuedAt: new Date('2024-01-02T00:00:00Z') });
+    });
+
+    expect(result.current.state.isExpanded).toBe(false);
+
+    unmount();
+    expect(commandPalette.unregister).toHaveBeenCalledWith('pgn-import:collapse');
+  });
+
+  it('collapses the pane and clears internal state', async () => {
+    const service = createService();
+    const { result } = renderHook(() => usePgnImport({ service }));
+
+    act(() => {
+      result.current.actions.activate('paste');
+    });
+
+    await act(async () => {
+      await result.current.actions.setSourceText('1.e4 e5 2.Nf3 Nc6');
+    });
+
+    act(() => {
+      result.current.actions.collapse();
+    });
+
+    expect(service.clear).toHaveBeenCalled();
+    expect(result.current.state).toMatchObject({
+      isExpanded: false,
+      mode: 'idle',
+      sourceText: '',
+      messages: [],
+      errors: [],
+    });
+    expect(result.current.state.preview).toBeUndefined();
+  });
+
+  it('handles PGN files by delegating to the service detect method', async () => {
+    const detect = vi.fn().mockResolvedValue(sampleOutcome);
+    const service = createService({ detect });
+    const { result } = renderHook(() => usePgnImport({ service }));
+
+    const file = new Blob(['1.e4 e5 2.Nf3 Nc6']);
+
+    await act(async () => {
+      await result.current.actions.importFromFile(file);
+    });
+
+    expect(detect).toHaveBeenCalledWith({ kind: 'file', value: file });
+    expect(result.current.state.mode).toBe('upload');
+    expect(result.current.state.preview).toEqual(sampleOutcome.preview);
+  });
+});

--- a/web-ui/src/application/hooks/usePgnImport.ts
+++ b/web-ui/src/application/hooks/usePgnImport.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  CommandHandler,
+  CommandPaletteService,
+  CommandRegistration,
+} from '../services/CommandPaletteService.js';
+import type {
+  PgnImportFeedbackMessage,
+  PgnImportOutcome,
+  PgnImportPreview,
+  PgnImportService,
+  PgnImportSource,
+} from '../services/PgnImportService.js';
+
+export type ImportMode = 'idle' | 'paste' | 'upload';
+
+export type UsePgnImportOptions = {
+  service: PgnImportService;
+  commandPalette?: CommandPaletteService;
+};
+
+export type UsePgnImportState = {
+  isExpanded: boolean;
+  mode: ImportMode;
+  sourceText: string;
+  preview?: PgnImportPreview;
+  messages: PgnImportFeedbackMessage[];
+  errors: string[];
+};
+
+export type UsePgnImportActions = {
+  activate: (mode: Exclude<ImportMode, 'idle'>) => void;
+  collapse: () => void;
+  setSourceText: (value: string) => Promise<void>;
+  importFromFile: (file: Blob | File) => Promise<void>;
+  acknowledgeMessages: () => void;
+};
+
+const collapseRegistration: CommandRegistration = {
+  id: 'pgn-import:collapse',
+  title: 'Close PGN import tools',
+  keywords: ['pgn', 'import', 'close'],
+  category: 'Import',
+  description: 'Collapse the PGN import pane.',
+};
+
+const isEmpty = (value: string): boolean => value.trim().length === 0;
+
+export const usePgnImport = ({
+  service,
+  commandPalette,
+}: UsePgnImportOptions): { state: UsePgnImportState; actions: UsePgnImportActions } => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [mode, setMode] = useState<ImportMode>('idle');
+  const [sourceText, setSourceTextState] = useState('');
+  const [preview, setPreview] = useState<PgnImportPreview | undefined>(undefined);
+  const [messages, setMessages] = useState<PgnImportFeedbackMessage[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
+  const lastOutcomeRef = useRef<PgnImportOutcome | undefined>(undefined);
+
+  const resetFeedback = useCallback(() => {
+    setPreview(undefined);
+    setMessages([]);
+    setErrors([]);
+    lastOutcomeRef.current = undefined;
+  }, []);
+
+  const collapse = useCallback(() => {
+    setIsExpanded(false);
+    setMode('idle');
+    setSourceTextState('');
+    resetFeedback();
+    service.clear();
+  }, [resetFeedback, service]);
+
+  const applyOutcome = useCallback((outcome: PgnImportOutcome) => {
+    lastOutcomeRef.current = outcome;
+    setPreview(outcome.preview);
+    setMessages(outcome.messages);
+    setErrors(outcome.errors);
+  }, []);
+
+  const detectSource = useCallback(
+    async (source: PgnImportSource): Promise<void> => {
+      const outcome = await service.detect(source);
+      applyOutcome(outcome);
+    },
+    [applyOutcome, service],
+  );
+
+  const activate = useCallback(
+    (nextMode: Exclude<ImportMode, 'idle'>) => {
+      setMode(nextMode);
+      setIsExpanded(true);
+      setSourceTextState('');
+      resetFeedback();
+    },
+    [resetFeedback],
+  );
+
+  const setSourceTextAction = useCallback(
+    async (value: string) => {
+      setIsExpanded(true);
+      setSourceTextState(value);
+
+      if (isEmpty(value)) {
+        resetFeedback();
+        return;
+      }
+
+      await detectSource({ kind: 'text', value });
+    },
+    [detectSource, resetFeedback],
+  );
+
+  const importFromFile = useCallback(
+    async (file: Blob | File) => {
+      setIsExpanded(true);
+      setMode('upload');
+
+      await detectSource({ kind: 'file', value: file });
+
+      const outcome = lastOutcomeRef.current;
+      if (outcome) {
+        setSourceTextState(outcome.preview.normalizedPgn);
+      }
+    },
+    [detectSource],
+  );
+
+  const acknowledgeMessages = useCallback(() => {
+    const outcome = lastOutcomeRef.current;
+    if (!outcome || outcome.messages.length === 0) {
+      setMessages([]);
+      return;
+    }
+
+    service.acknowledge(outcome);
+    lastOutcomeRef.current = {
+      ...outcome,
+      messages: [],
+    } satisfies PgnImportOutcome;
+    setMessages([]);
+  }, [service]);
+
+  useEffect(() => {
+    if (!commandPalette) {
+      return undefined;
+    }
+
+    const handler: CommandHandler = async () => {
+      collapse();
+      return undefined;
+    };
+
+    commandPalette.register(collapseRegistration, handler);
+    return () => {
+      commandPalette.unregister(collapseRegistration.id);
+    };
+  }, [commandPalette, collapse]);
+
+  const state = useMemo<UsePgnImportState>(
+    () => ({
+      isExpanded,
+      mode,
+      sourceText,
+      preview,
+      messages,
+      errors,
+    }),
+    [errors, isExpanded, messages, mode, preview, sourceText],
+  );
+
+  const actions = useMemo<UsePgnImportActions>(
+    () => ({
+      activate,
+      collapse,
+      setSourceText: setSourceTextAction,
+      importFromFile,
+      acknowledgeMessages,
+    }),
+    [acknowledgeMessages, activate, collapse, importFromFile, setSourceTextAction],
+  );
+
+  return { state, actions };
+};

--- a/web-ui/src/application/services/PgnImportService.ts
+++ b/web-ui/src/application/services/PgnImportService.ts
@@ -2,6 +2,7 @@ import type {
   DetectedOpeningLine,
   ScheduledOpeningLine,
 } from '../../types/repertoire';
+import type { ImportPlan, ImportPlanner } from './ImportPlanner.js';
 
 export type PgnImportSource = {
   kind: 'text' | 'file';
@@ -33,3 +34,224 @@ export interface PgnImportService {
   acknowledge(outcome: PgnImportOutcome): void;
   clear(): void;
 }
+
+type OpeningPattern = {
+  opening: string;
+  color: DetectedOpeningLine['color'];
+  moves: readonly string[];
+};
+
+const DEFAULT_PATTERNS: readonly OpeningPattern[] = [
+  {
+    opening: 'Danish Gambit',
+    color: 'White',
+    moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+  },
+  {
+    opening: "King's Knight Opening",
+    color: 'White',
+    moves: ['e4', 'e5', 'Nf3'],
+  },
+] as const;
+
+const CLEAN_TAG_PATTERN = /\[[^\]]*\]/g;
+const CLEAN_COMMENT_PATTERN = /\{[^}]*\}/g;
+const CLEAN_VARIATION_PATTERN = /\([^)]*\)/g;
+
+const sanitizeMoves = (input: string): string[] => {
+  const cleaned = input
+    .replace(CLEAN_TAG_PATTERN, ' ')
+    .replace(CLEAN_COMMENT_PATTERN, ' ')
+    .replace(CLEAN_VARIATION_PATTERN, ' ');
+
+  return cleaned
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    .map((token) => token.replace(/^[0-9]+\.\.\./, ''))
+    .map((token) => token.replace(/^[0-9]+\./, ''))
+    .map((token) => token.replace(/[?!+#]/g, ''))
+    .filter((token) => token.length > 0);
+};
+
+const formatMoveSequence = (moves: string[]): string => {
+  const segments: string[] = [];
+  for (let index = 0; index < moves.length; index += 2) {
+    const moveNumber = Math.floor(index / 2) + 1;
+    const whiteMove = moves[index];
+    const blackMove = moves[index + 1];
+
+    if (whiteMove) {
+      segments.push(`${String(moveNumber)}.${whiteMove}`);
+    }
+
+    if (blackMove) {
+      segments.push(blackMove);
+    }
+  }
+  return segments.join(' ');
+};
+
+const detectOpening = (
+  moves: string[],
+  patterns: readonly OpeningPattern[],
+): DetectedOpeningLine | undefined => {
+  if (moves.length === 0) {
+    return undefined;
+  }
+
+  const normalized = moves.map((move) => move.toLowerCase());
+
+  const matchedPattern = patterns.find((pattern) => {
+    if (normalized.length < pattern.moves.length) {
+      return false;
+    }
+
+    return pattern.moves.every((expectedMove, index) => {
+      return normalized[index] === expectedMove.toLowerCase();
+    });
+  });
+
+  if (!matchedPattern) {
+    return undefined;
+  }
+
+  return {
+    opening: matchedPattern.opening,
+    color: matchedPattern.color,
+    moves,
+    display: formatMoveSequence(moves),
+  } satisfies DetectedOpeningLine;
+};
+
+const defaultReadText = async (blob: Blob | File): Promise<string> => {
+  if (typeof (blob as File).text === 'function') {
+    return (blob as File).text();
+  }
+
+  throw new Error('Cannot read PGN text');
+};
+
+const deriveMessageTone = (headline: string): 'success' | 'info' => {
+  return /already/i.test(headline) ? 'info' : 'success';
+};
+
+const toFeedbackMessage = (
+  plan: ImportPlan,
+  idFactory: () => string,
+  dispatchAt: Date,
+  acknowledgedHeadlines: Set<string>,
+): PgnImportFeedbackMessage | undefined => {
+  if (!plan.messages.length) {
+    return undefined;
+  }
+
+  const [headline, ...rest] = plan.messages;
+
+  if (!headline || acknowledgedHeadlines.has(headline)) {
+    return undefined;
+  }
+
+  return {
+    id: idFactory(),
+    tone: deriveMessageTone(headline),
+    headline,
+    body: rest.length > 0 ? rest.join(' ') : undefined,
+    dispatchAt,
+  } satisfies PgnImportFeedbackMessage;
+};
+
+const createEmptyPreview = (): PgnImportPreview => ({
+  normalizedPgn: '',
+  detectedLines: [],
+  scheduledLines: [],
+});
+
+type ServiceDependencies = {
+  importPlanner: ImportPlanner;
+  idFactory?: () => string;
+  clock?: () => Date;
+  readText?: (blob: Blob | File) => Promise<string>;
+  patterns?: readonly OpeningPattern[];
+};
+
+export const createPgnImportService = ({
+  importPlanner,
+  idFactory = () => crypto.randomUUID(),
+  clock = () => new Date(),
+  readText = defaultReadText,
+  patterns = DEFAULT_PATTERNS,
+}: ServiceDependencies): PgnImportService => {
+  const acknowledgedHeadlines = new Set<string>();
+
+  const buildOutcome = (
+    normalizedPgn: string,
+    detectedLines: DetectedOpeningLine[],
+    plans: ImportPlan[],
+    errors: string[],
+  ): PgnImportOutcome => {
+    const scheduledLines = plans.map((plan) => plan.line);
+    const dispatchAt = clock();
+    const messages = plans
+      .map((plan) => toFeedbackMessage(plan, idFactory, dispatchAt, acknowledgedHeadlines))
+      .filter((message): message is PgnImportFeedbackMessage => Boolean(message));
+
+    return {
+      preview: {
+        normalizedPgn,
+        detectedLines,
+        scheduledLines,
+      },
+      messages,
+      errors,
+    } satisfies PgnImportOutcome;
+  };
+
+  const handleDetection = async (text: string): Promise<PgnImportOutcome> => {
+    const moves = sanitizeMoves(text);
+    const normalizedPgn = moves.length > 0 ? formatMoveSequence(moves) : '';
+    const detected = detectOpening(moves, patterns);
+
+    if (!detected) {
+      return buildOutcome(normalizedPgn, [], [], [
+        "We could not recognize that PGN yet. Try a standard Danish Gambit or King's Knight Opening line.",
+      ]);
+    }
+
+    try {
+      const plans = importPlanner.planBulk([detected], clock());
+      return buildOutcome(normalizedPgn, [detected], plans, []);
+    } catch (error) {
+      return buildOutcome(normalizedPgn, [detected], [], [
+        error instanceof Error ? error.message : 'Unable to schedule the detected opening.',
+      ]);
+    }
+  };
+
+  return {
+    async detect(source) {
+      if (source.kind === 'text') {
+        return handleDetection(String(source.value ?? ''));
+      }
+
+      try {
+        const text = await readText(source.value as File | Blob);
+        return handleDetection(text);
+      } catch (error) {
+        return {
+          preview: createEmptyPreview(),
+          messages: [],
+          errors: ['We could not read that PGN file. Please try again.'],
+        } satisfies PgnImportOutcome;
+      }
+    },
+    acknowledge(outcome) {
+      outcome.messages.forEach((message) => {
+        acknowledgedHeadlines.add(message.headline);
+      });
+    },
+    clear() {
+      acknowledgedHeadlines.clear();
+    },
+  } satisfies PgnImportService;
+};

--- a/web-ui/src/application/services/__tests__/pgn-import-service.spec.ts
+++ b/web-ui/src/application/services/__tests__/pgn-import-service.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import type { ImportPlan, ImportPlanner } from '../ImportPlanner.js';
+import { createPgnImportService } from '../PgnImportService.js';
+
+const buildPlanner = (plans: ImportPlan[]): ImportPlanner => {
+  return {
+    planLine: vi.fn(() => {
+      if (plans.length === 0) {
+        throw new Error('no plans available');
+      }
+      return plans[0];
+    }),
+    planBulk: vi.fn(() => plans),
+    persist: vi.fn(async () => {
+      // no-op for tests
+    }),
+  } satisfies ImportPlanner;
+};
+
+describe('createPgnImportService', () => {
+  const sampleDetectedLine = {
+    opening: 'Danish Gambit',
+    color: 'White',
+    moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+    display: '1.e4 e5 2.d4 exd4 3.c3',
+  };
+
+  const samplePlan: ImportPlan = {
+    line: {
+      ...sampleDetectedLine,
+      id: 'line-1',
+      scheduledFor: '2024-01-05',
+    },
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    messages: ['Scheduled for 2024-01-05 in your white Danish Gambit repertoire.'],
+  };
+
+  const detectionSource = '1. e4 e5 2. d4 exd4 3. c3';
+
+  const factory = () =>
+    createPgnImportService({
+      importPlanner: buildPlanner([samplePlan]),
+      idFactory: () => 'message-1',
+      clock: () => new Date('2024-01-02T00:00:00Z'),
+    });
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('detects a supported opening from text sources and schedules planner messages', async () => {
+    const service = factory();
+
+    const outcome = await service.detect({ kind: 'text', value: detectionSource });
+
+    expect(outcome.preview.normalizedPgn).toEqual('1.e4 e5 2.d4 exd4 3.c3');
+    expect(outcome.preview.detectedLines).toEqual([sampleDetectedLine]);
+    expect(outcome.preview.scheduledLines).toEqual([samplePlan.line]);
+    expect(outcome.messages).toEqual([
+      {
+        id: 'message-1',
+        tone: 'success',
+        headline: samplePlan.messages[0],
+        body: undefined,
+        dispatchAt: new Date('2024-01-02T00:00:00Z'),
+      },
+    ]);
+    expect(outcome.errors).toEqual([]);
+  });
+
+  it('only emits planner messages once they are acknowledged', async () => {
+    const service = factory();
+
+    const firstOutcome = await service.detect({ kind: 'text', value: detectionSource });
+    service.acknowledge(firstOutcome);
+
+    const secondOutcome = await service.detect({ kind: 'text', value: detectionSource });
+
+    expect(secondOutcome.messages).toEqual([]);
+
+    service.clear();
+
+    const thirdOutcome = await service.detect({ kind: 'text', value: detectionSource });
+    expect(thirdOutcome.messages).toHaveLength(1);
+  });
+
+  it('returns meaningful errors when no opening is detected', async () => {
+    const service = factory();
+
+    const outcome = await service.detect({ kind: 'text', value: '1. d4 Nf6 2. c4 g6' });
+
+    expect(outcome.preview.detectedLines).toEqual([]);
+    expect(outcome.preview.scheduledLines).toEqual([]);
+    expect(outcome.messages).toEqual([]);
+    expect(outcome.errors).toEqual([
+      "We could not recognize that PGN yet. Try a standard Danish Gambit or King's Knight Opening line.",
+    ]);
+  });
+
+  it('normalizes text extracted from a PGN file source', async () => {
+    const textBlob = new Blob([detectionSource]);
+    const readText = vi.fn(async () => detectionSource);
+    const service = createPgnImportService({
+      importPlanner: buildPlanner([samplePlan]),
+      idFactory: () => 'message-1',
+      clock: () => new Date('2024-01-02T00:00:00Z'),
+      readText,
+    });
+
+    const outcome = await service.detect({ kind: 'file', value: textBlob });
+
+    expect(readText).toHaveBeenCalledWith(textBlob);
+    expect(outcome.preview.detectedLines).toHaveLength(1);
+    expect(outcome.errors).toEqual([]);
+  });
+
+  it('reports errors when a PGN file cannot be read', async () => {
+    const service = createPgnImportService({
+      importPlanner: buildPlanner([]),
+      idFactory: () => 'message-1',
+      clock: () => new Date('2024-01-02T00:00:00Z'),
+      readText: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    const outcome = await service.detect({ kind: 'file', value: new Blob([]) });
+
+    expect(outcome.preview.detectedLines).toEqual([]);
+    expect(outcome.errors).toEqual(['We could not read that PGN file. Please try again.']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a production PgnImportService that parses PGN sources, normalises move previews, and emits planner-driven feedback messages
- introduce a usePgnImport hook that owns pane state, command registration, and feedback acknowledgement around the new service
- cover the service and hook with Vitest suites to exercise detection success, error states, and command wiring

## Testing
- npm run test -- pgn-import-service.spec.ts usePgnImport.spec.tsx
- npm run typecheck
- make test *(fails: clippy reports existing borrow-as-ptr and float-cmp violations under crates/review-domain/src/card.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfde1857c8325bd2022772f219989