### PR TITLE
Implement import planner service with tests

### DIFF
--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -88,8 +88,10 @@ mod tests {
         let clone = original.clone();
 
         assert_eq!(original, clone);
-        assert!(std::ptr::eq(&original, &original));
-        assert!(!std::ptr::eq(&original, &clone));
+        let original_ptr = std::ptr::addr_of!(original);
+        let clone_ptr = std::ptr::addr_of!(clone);
+        assert!(std::ptr::eq(original_ptr, original_ptr));
+        assert!(!std::ptr::eq(original_ptr, clone_ptr));
     }
 
     #[test]
@@ -105,7 +107,7 @@ mod tests {
         card.state.interval_days += 5;
         card.state.lapses += 1;
 
-        assert_eq!(card.state.ease, 2.8);
+        assert!((card.state.ease - 2.8).abs() < f32::EPSILON);
         assert_eq!(card.state.interval_days, 15);
         assert_eq!(card.state.lapses, 1);
     }

--- a/web-ui/src/application/services/ImportPlanner.ts
+++ b/web-ui/src/application/services/ImportPlanner.ts
@@ -14,3 +14,88 @@ export interface ImportPlanner {
   planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[];
   persist(plan: ImportPlan): Promise<void>;
 }
+
+type Clock = () => Date;
+type IdGenerator = () => string;
+type PersistHandler = (line: ScheduledOpeningLine) => Promise<void> | void;
+
+export type ImportPlannerOptions = {
+  clock?: Clock;
+  idGenerator?: IdGenerator;
+  persistLine?: PersistHandler;
+  initialLines?: ScheduledOpeningLine[];
+};
+
+const formatDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+const calculateScheduledDate = (baseDate: Date, offset: number): string => {
+  const next = new Date(baseDate.getTime());
+  next.setUTCDate(next.getUTCDate() + 1 + offset);
+  return formatDate(next);
+};
+
+const createLineKey = (line: DetectedOpeningLine | ScheduledOpeningLine): string => {
+  const moves = line.moves.map((move) => move.trim().toLowerCase()).join('#');
+  return `${line.color.toLowerCase()}::${line.opening.toLowerCase()}::${moves}`;
+};
+
+export class DefaultImportPlanner implements ImportPlanner {
+  private readonly clock: Clock;
+
+  private readonly idGenerator: IdGenerator;
+
+  private readonly persistLine?: PersistHandler;
+
+  private readonly knownLines: Map<string, ScheduledOpeningLine>;
+
+  public constructor(options: ImportPlannerOptions = {}) {
+    this.clock = options.clock ?? (() => new Date());
+    this.idGenerator = options.idGenerator ?? (() => crypto.randomUUID());
+    this.persistLine = options.persistLine;
+    this.knownLines = new Map(
+      (options.initialLines ?? []).map((line) => [createLineKey(line), line] as const),
+    );
+  }
+
+  public planLine(line: DetectedOpeningLine, referenceDate?: Date): ImportPlan {
+    const baseDate = referenceDate ? new Date(referenceDate.getTime()) : this.clock();
+    const createdAt = new Date(baseDate.getTime());
+    const key = createLineKey(line);
+    const existing = this.knownLines.get(key);
+
+    if (existing) {
+      return {
+        line: existing,
+        createdAt,
+        messages: [`Already scheduled for ${existing.scheduledFor}`],
+      } satisfies ImportPlan;
+    }
+
+    const scheduledFor = calculateScheduledDate(baseDate, this.knownLines.size);
+    const scheduledLine: ScheduledOpeningLine = {
+      ...line,
+      id: this.idGenerator(),
+      scheduledFor,
+    };
+
+    this.knownLines.set(key, scheduledLine);
+
+    return {
+      line: scheduledLine,
+      createdAt,
+      messages: [`Scheduled for ${scheduledFor}`],
+    } satisfies ImportPlan;
+  }
+
+  public planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[] {
+    return lines.map((line) => this.planLine(line, referenceDate));
+  }
+
+  public async persist(plan: ImportPlan): Promise<void> {
+    if (!this.persistLine) {
+      return;
+    }
+
+    await this.persistLine(plan.line);
+  }
+}

--- a/web-ui/src/application/services/__tests__/import-planner.spec.ts
+++ b/web-ui/src/application/services/__tests__/import-planner.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DetectedOpeningLine } from '../../../types/repertoire';
+import { DefaultImportPlanner } from '../ImportPlanner.js';
+
+describe('DefaultImportPlanner', () => {
+  const sampleLine: DetectedOpeningLine = {
+    opening: 'Danish Gambit',
+    color: 'White',
+    moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+    display: '1.e4 e5 2.d4 exd4 3.c3',
+  };
+
+  const buildPlanner = (
+    overrides: Partial<ConstructorParameters<typeof DefaultImportPlanner>[0]> = {},
+  ) => {
+    const clockDate = new Date('2024-05-01T08:00:00.000Z');
+    let nextId = 1;
+    return new DefaultImportPlanner({
+      clock: () => clockDate,
+      idGenerator: () => `line-${nextId++}`,
+      ...overrides,
+    });
+  };
+
+  it('schedules a new line for the next available day', () => {
+    const planner = buildPlanner();
+
+    const plan = planner.planLine(sampleLine);
+
+    expect(plan.line.id).toBe('line-1');
+    expect(plan.line.scheduledFor).toBe('2024-05-02');
+    expect(plan.line.opening).toBe(sampleLine.opening);
+    expect(plan.createdAt.toISOString()).toBe('2024-05-01T08:00:00.000Z');
+    expect(plan.messages[0]).toContain('Scheduled');
+  });
+
+  it('returns the existing schedule when the line is already planned', () => {
+    const planner = buildPlanner();
+
+    const firstPlan = planner.planLine(sampleLine);
+    const secondPlan = planner.planLine(sampleLine);
+
+    expect(secondPlan.line).toEqual(firstPlan.line);
+    expect(secondPlan.messages[0]).toContain('Already scheduled');
+  });
+
+  it('increments the schedule date for each additional line', () => {
+    const planner = buildPlanner();
+
+    const extraLine: DetectedOpeningLine = {
+      opening: "King's Knight Opening",
+      color: 'White',
+      moves: ['e4', 'e5', 'Nf3'],
+      display: '1.e4 e5 2.Nf3',
+    };
+
+    const [firstPlan, secondPlan] = planner.planBulk([sampleLine, extraLine]);
+
+    expect(firstPlan.line.id).toBe('line-1');
+    expect(firstPlan.line.scheduledFor).toBe('2024-05-02');
+    expect(secondPlan.line.id).toBe('line-2');
+    expect(secondPlan.line.scheduledFor).toBe('2024-05-03');
+  });
+
+  it('persists a plan using the configured persistence handler', async () => {
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const planner = buildPlanner({ persistLine: persist });
+
+    const plan = planner.planLine(sampleLine);
+    await planner.persist(plan);
+
+    expect(persist).toHaveBeenCalledWith(plan.line);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `DefaultImportPlanner` to turn the application-layer interface into a concrete scheduling service with deduplication and configurable dependencies
- add unit tests that drive the planner through scheduling, duplicate detection, bulk planning, and persistence hooks
- adjust review-domain unit tests to satisfy clippy::pedantic requirements triggered by the repository test harness

## Testing
- npm test -- --run import-planner

------
https://chatgpt.com/codex/tasks/task_e_68ebfdf7e01483258b4a838638c3a932