### PR TITLE
Add chessboard configuration data class

### DIFF
--- a/web-ui/src/types/__tests__/ChessboardConfig.test.ts
+++ b/web-ui/src/types/__tests__/ChessboardConfig.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChessboardConfig } from '../chessboardConfig';
+
+describe('ChessboardConfig', () => {
+  it('provides chessboard-element defaults out of the box', () => {
+    const config = new ChessboardConfig();
+
+    expect(config.orientation).toBe('white');
+    expect(config.showCoordinates).toBe(true);
+    expect(config.hideNotation).toBe(false);
+    expect(config.draggablePieces).toBe(false);
+    expect(config.dropOffBoard).toBe('snapback');
+    expect(config.animation).toEqual({
+      moveSpeed: 200,
+      snapbackSpeed: 60,
+      snapSpeed: 30,
+      trashSpeed: 100,
+      appearSpeed: 200,
+    });
+    expect(config.style).toEqual({
+      lightSquareColor: '#f0d9b5',
+      darkSquareColor: '#b58863',
+      highlightColor: 'yellow',
+    });
+    expect(config.toCssVariables()).toEqual({
+      '--light-color': '#f0d9b5',
+      '--dark-color': '#b58863',
+      '--highlight-color': 'yellow',
+    });
+    expect(Object.isFrozen(config.animation)).toBe(true);
+    expect(Object.isFrozen(config.style)).toBe(true);
+    expect(Object.isFrozen(config.eventHandlers)).toBe(true);
+  });
+
+  it('merges overrides without mutating the base config', () => {
+    const dropHandler = vi.fn();
+    const base = new ChessboardConfig({
+      orientation: 'black',
+      showCoordinates: false,
+      draggablePieces: true,
+      animation: { moveSpeed: 'fast' },
+      style: { highlightColor: '#ff00ff' },
+      eventHandlers: { onDrop: dropHandler },
+    });
+
+    const overrideChangeHandler = vi.fn();
+    const updated = base.withOverrides({
+      showCoordinates: true,
+      animation: { snapSpeed: 150 },
+      style: { darkSquareColor: '#222222' },
+      eventHandlers: { onChange: overrideChangeHandler },
+    });
+
+    expect(updated).not.toBe(base);
+    expect(updated.orientation).toBe('black');
+    expect(updated.showCoordinates).toBe(true);
+    expect(updated.draggablePieces).toBe(true);
+    expect(updated.animation).toEqual({
+      moveSpeed: 'fast',
+      snapbackSpeed: 60,
+      snapSpeed: 150,
+      trashSpeed: 100,
+      appearSpeed: 200,
+    });
+    expect(updated.style).toEqual({
+      lightSquareColor: '#f0d9b5',
+      darkSquareColor: '#222222',
+      highlightColor: '#ff00ff',
+    });
+    expect(updated.eventHandlers.onDrop).toBe(dropHandler);
+    expect(updated.eventHandlers.onChange).toBe(overrideChangeHandler);
+
+    expect(base.showCoordinates).toBe(false);
+    expect(base.animation.snapSpeed).toBe(30);
+    expect(base.style.darkSquareColor).toBe('#b58863');
+  });
+});

--- a/web-ui/src/types/chessboardConfig.ts
+++ b/web-ui/src/types/chessboardConfig.ts
@@ -1,0 +1,237 @@
+import type {
+  AnimationSpeed,
+  OffBoardAction,
+  PositionObject,
+  RenderPieceFunction,
+  SquareColor,
+} from 'chessboard-element/lib/chessboard-element';
+import type { Position } from 'chessboard-element/lib/chess-utils';
+
+export interface ChessboardSquareEventDetail {
+  square: string;
+  piece: string | false;
+  position: PositionObject;
+  orientation: SquareColor;
+}
+
+export interface ChessboardSnapbackEventDetail {
+  piece: string;
+  square: string;
+  position: PositionObject;
+  orientation: SquareColor;
+}
+
+export interface ChessboardSnapEventDetail {
+  source: string;
+  square: string;
+  piece: string;
+}
+
+export interface ChessboardDragStartEventDetail {
+  source: string;
+  piece: string;
+  position: PositionObject;
+  orientation: SquareColor;
+}
+
+export interface ChessboardDragMoveEventDetail {
+  newLocation: string;
+  oldLocation: string;
+  source: string;
+  piece: string;
+  position: PositionObject;
+  orientation: SquareColor;
+}
+
+export interface ChessboardDropEventDetail {
+  source: string;
+  target: string;
+  piece: string;
+  newPosition: PositionObject;
+  oldPosition: PositionObject;
+  orientation: SquareColor;
+  setAction: (action: OffBoardAction) => void;
+}
+
+export interface ChessboardMoveEndEventDetail {
+  oldPosition: PositionObject;
+  newPosition: PositionObject;
+}
+
+export interface ChessboardChangeEventDetail {
+  value: PositionObject;
+  oldValue: PositionObject;
+}
+
+export interface ChessboardEventHandlers {
+  onMouseoverSquare?: (event: CustomEvent<ChessboardSquareEventDetail>) => void;
+  onMouseoutSquare?: (event: CustomEvent<ChessboardSquareEventDetail>) => void;
+  onSnapbackEnd?: (event: CustomEvent<ChessboardSnapbackEventDetail>) => void;
+  onSnapEnd?: (event: CustomEvent<ChessboardSnapEventDetail>) => void;
+  onDragStart?: (event: CustomEvent<ChessboardDragStartEventDetail>) => void;
+  onDragMove?: (event: CustomEvent<ChessboardDragMoveEventDetail>) => void;
+  onDrop?: (event: CustomEvent<ChessboardDropEventDetail>) => void;
+  onMoveEnd?: (event: CustomEvent<ChessboardMoveEndEventDetail>) => void;
+  onChange?: (event: CustomEvent<ChessboardChangeEventDetail>) => void;
+  onError?: (event: Event) => void;
+}
+
+export interface ChessboardAnimationOptions {
+  moveSpeed?: AnimationSpeed;
+  snapbackSpeed?: AnimationSpeed;
+  snapSpeed?: AnimationSpeed;
+  trashSpeed?: AnimationSpeed;
+  appearSpeed?: AnimationSpeed;
+}
+
+export interface ChessboardStyleOptions {
+  lightSquareColor?: string;
+  darkSquareColor?: string;
+  highlightColor?: string;
+}
+
+export interface ChessboardConfigOptions {
+  position?: Position;
+  orientation?: SquareColor;
+  showCoordinates?: boolean;
+  draggablePieces?: boolean;
+  dropOffBoard?: OffBoardAction;
+  pieceTheme?: string | ((piece: string) => string);
+  renderPiece?: RenderPieceFunction;
+  animation?: ChessboardAnimationOptions;
+  sparePieces?: boolean;
+  style?: ChessboardStyleOptions;
+  eventHandlers?: ChessboardEventHandlers;
+}
+
+export type NormalizedChessboardAnimationOptions = Readonly<{
+  moveSpeed: AnimationSpeed;
+  snapbackSpeed: AnimationSpeed;
+  snapSpeed: AnimationSpeed;
+  trashSpeed: AnimationSpeed;
+  appearSpeed: AnimationSpeed;
+}>;
+
+export type NormalizedChessboardStyleOptions = Readonly<{
+  lightSquareColor: string;
+  darkSquareColor: string;
+  highlightColor: string;
+}>;
+
+export class ChessboardConfig {
+  readonly position?: Position;
+
+  readonly orientation: SquareColor;
+
+  readonly showCoordinates: boolean;
+
+  readonly draggablePieces: boolean;
+
+  readonly dropOffBoard: OffBoardAction;
+
+  readonly pieceTheme?: string | ((piece: string) => string);
+
+  readonly renderPiece?: RenderPieceFunction;
+
+  readonly animation: NormalizedChessboardAnimationOptions;
+
+  readonly sparePieces: boolean;
+
+  readonly style: NormalizedChessboardStyleOptions;
+
+  readonly eventHandlers: Readonly<ChessboardEventHandlers>;
+
+  constructor(options: ChessboardConfigOptions = {}) {
+    const {
+      position,
+      orientation,
+      showCoordinates,
+      draggablePieces,
+      dropOffBoard,
+      pieceTheme,
+      renderPiece,
+      animation,
+      sparePieces,
+      style,
+      eventHandlers,
+    } = options;
+
+    this.position = position;
+    this.orientation = orientation ?? 'white';
+    this.showCoordinates = showCoordinates ?? true;
+    this.draggablePieces = draggablePieces ?? false;
+    this.dropOffBoard = dropOffBoard ?? 'snapback';
+    this.pieceTheme = pieceTheme;
+    this.renderPiece = renderPiece;
+    this.animation = Object.freeze({
+      moveSpeed: animation?.moveSpeed ?? 200,
+      snapbackSpeed: animation?.snapbackSpeed ?? 60,
+      snapSpeed: animation?.snapSpeed ?? 30,
+      trashSpeed: animation?.trashSpeed ?? 100,
+      appearSpeed: animation?.appearSpeed ?? 200,
+    });
+    this.sparePieces = sparePieces ?? false;
+    this.style = Object.freeze({
+      lightSquareColor: style?.lightSquareColor ?? '#f0d9b5',
+      darkSquareColor: style?.darkSquareColor ?? '#b58863',
+      highlightColor: style?.highlightColor ?? 'yellow',
+    });
+    this.eventHandlers = Object.freeze({ ...(eventHandlers ?? {}) });
+  }
+
+  get showNotation(): boolean {
+    return this.showCoordinates;
+  }
+
+  get hideNotation(): boolean {
+    return !this.showCoordinates;
+  }
+
+  toCssVariables(): Record<string, string> {
+    return {
+      '--light-color': this.style.lightSquareColor,
+      '--dark-color': this.style.darkSquareColor,
+      '--highlight-color': this.style.highlightColor,
+    };
+  }
+
+  toObject(): ChessboardConfigOptions {
+    return {
+      position: this.position,
+      orientation: this.orientation,
+      showCoordinates: this.showCoordinates,
+      draggablePieces: this.draggablePieces,
+      dropOffBoard: this.dropOffBoard,
+      pieceTheme: this.pieceTheme,
+      renderPiece: this.renderPiece,
+      animation: { ...this.animation },
+      sparePieces: this.sparePieces,
+      style: { ...this.style },
+      eventHandlers: { ...this.eventHandlers },
+    };
+  }
+
+  withOverrides(overrides: ChessboardConfigOptions): ChessboardConfig {
+    const base = this.toObject();
+    const mergedAnimation = {
+      ...(base.animation ?? {}),
+      ...(overrides.animation ?? {}),
+    } satisfies ChessboardAnimationOptions;
+    const mergedStyle = {
+      ...(base.style ?? {}),
+      ...(overrides.style ?? {}),
+    } satisfies ChessboardStyleOptions;
+    const mergedHandlers = {
+      ...(base.eventHandlers ?? {}),
+      ...(overrides.eventHandlers ?? {}),
+    } satisfies ChessboardEventHandlers;
+
+    return new ChessboardConfig({
+      ...base,
+      ...overrides,
+      animation: mergedAnimation,
+      style: mergedStyle,
+      eventHandlers: mergedHandlers,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a `ChessboardConfig` data class that captures chessboard-element configuration, styling, and event handler types
- provide helpers for deriving CSS variables and merging override sets immutably
- cover the configuration defaults and override behavior with dedicated unit tests

## Testing
- npm run test
- make test *(fails: clippy::borrow-as-ptr and clippy::float-cmp errors in crates/review-domain/src/card.rs unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ebffa93b9c8325b8077984028505e8