### PR TITLE
Implement opening graph adjacency helpers

### DIFF
--- a/crates/card-store/tests/opening_graph.rs
+++ b/crates/card-store/tests/opening_graph.rs
@@ -1,0 +1,55 @@
+use review_domain::opening::OpeningGraph;
+use review_domain::repertoire::{Repertoire, RepertoireMove};
+
+fn sample_moves() -> Vec<RepertoireMove> {
+    vec![
+        RepertoireMove::new(1, 10, 20, "e2e4", "e4"),
+        RepertoireMove::new(2, 10, 30, "d2d4", "d4"),
+        RepertoireMove::new(3, 20, 40, "g1f3", "Nf3"),
+    ]
+}
+
+#[test]
+fn opening_graph_behaviour_remains_stable() {
+    let graph = OpeningGraph::from_moves(sample_moves());
+
+    let children = graph.children(10);
+    assert_eq!(children.len(), 2);
+    assert_eq!(children[0].id, 1);
+    assert_eq!(children[1].id, 2);
+
+    let parents = graph.parents(40);
+    assert_eq!(parents.len(), 1);
+    assert_eq!(parents[0].id, 3);
+
+    let path = graph.path_to(40).expect("path exists");
+    let ids: Vec<u64> = path.iter().map(|edge| edge.id).collect();
+    assert_eq!(ids, vec![1, 3]);
+}
+
+#[test]
+fn opening_graph_from_repertoire_and_unknowns() {
+    let repertoire = Repertoire::from_iter(sample_moves().clone());
+    let graph = OpeningGraph::from_repertoire(&repertoire);
+
+    assert!(graph.path_to(999).is_none());
+    assert!(graph.children(999).is_empty());
+    assert!(graph.parents(999).is_empty());
+
+    let root_path = graph.path_to(10).expect("root exists");
+    assert!(root_path.is_empty());
+}
+
+#[test]
+fn opening_graph_deduplicates_edges_and_detects_cycles() {
+    let mut moves = sample_moves();
+    // Duplicate edge to trigger the early return branch in insert_edge.
+    moves.push(RepertoireMove::new(1, 10, 20, "e2e4", "e4"));
+    let deduped = OpeningGraph::from_moves(moves.clone());
+    assert_eq!(deduped.children(10).len(), 2);
+
+    // Introduce a cycle (40 -> 10) to exercise the visited detection.
+    moves.push(RepertoireMove::new(4, 40, 10, "a2a3", "a3"));
+    let cyclic_graph = OpeningGraph::from_moves(moves);
+    assert!(cyclic_graph.path_to(10).is_none());
+}

--- a/crates/chess-training-pgn-import/tests/opening_graph.rs
+++ b/crates/chess-training-pgn-import/tests/opening_graph.rs
@@ -1,0 +1,44 @@
+use review_domain::opening::OpeningGraph;
+use review_domain::repertoire::{Repertoire, RepertoireMove};
+
+fn sample_moves() -> Vec<RepertoireMove> {
+    vec![
+        RepertoireMove::new(1, 10, 20, "e2e4", "e4"),
+        RepertoireMove::new(2, 10, 30, "d2d4", "d4"),
+        RepertoireMove::new(3, 20, 40, "g1f3", "Nf3"),
+    ]
+}
+
+#[test]
+fn opening_graph_from_repertoire_matches_moves() {
+    let repertoire = Repertoire::from_iter(sample_moves().clone());
+    let graph = OpeningGraph::from_repertoire(&repertoire);
+
+    let children = graph.children(10);
+    assert_eq!(children.len(), 2);
+    assert_eq!(children[0].id, 1);
+    assert_eq!(children[1].id, 2);
+}
+
+#[test]
+fn opening_graph_unknowns_and_roots() {
+    let graph = OpeningGraph::from_moves(sample_moves());
+    assert!(graph.path_to(999).is_none());
+    assert!(graph.children(999).is_empty());
+    assert!(graph.parents(999).is_empty());
+
+    let root_path = graph.path_to(10).expect("root exists");
+    assert!(root_path.is_empty());
+}
+
+#[test]
+fn opening_graph_cycle_protection() {
+    let mut moves = sample_moves();
+    moves.push(RepertoireMove::new(1, 10, 20, "e2e4", "e4"));
+    let deduped = OpeningGraph::from_moves(moves.clone());
+    assert_eq!(deduped.children(10).len(), 2);
+
+    moves.push(RepertoireMove::new(4, 40, 10, "a2a3", "a3"));
+    let cyclic_graph = OpeningGraph::from_moves(moves);
+    assert!(cyclic_graph.path_to(10).is_none());
+}

--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -88,8 +88,11 @@ mod tests {
         let clone = original.clone();
 
         assert_eq!(original, clone);
-        assert!(std::ptr::eq(&original, &original));
-        assert!(!std::ptr::eq(&original, &clone));
+        let original_ptr = std::ptr::from_ref(&original);
+        let clone_ptr = std::ptr::from_ref(&clone);
+
+        assert!(std::ptr::eq(original_ptr, original_ptr));
+        assert!(!std::ptr::eq(original_ptr, clone_ptr));
     }
 
     #[test]
@@ -105,7 +108,7 @@ mod tests {
         card.state.interval_days += 5;
         card.state.lapses += 1;
 
-        assert_eq!(card.state.ease, 2.8);
+        assert!((card.state.ease - 2.8).abs() < f32::EPSILON);
         assert_eq!(card.state.interval_days, 15);
         assert_eq!(card.state.lapses, 1);
     }

--- a/crates/review-domain/src/opening/graph.rs
+++ b/crates/review-domain/src/opening/graph.rs
@@ -1,0 +1,181 @@
+//! Opening graph adjacency structure for repertoire traversal.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    opening::OpeningEdge,
+    repertoire::{Repertoire, RepertoireMove},
+};
+
+/// Directed acyclic graph representation of opening positions and edges.
+#[derive(Default)]
+pub struct OpeningGraph {
+    edges: HashMap<u64, OpeningEdge>,
+    outgoing: HashMap<u64, Vec<u64>>, // parent position -> edge ids
+    incoming: HashMap<u64, Vec<u64>>, // child position -> edge ids
+}
+
+impl OpeningGraph {
+    /// Builds a graph from the moves stored in a [`Repertoire`].
+    #[must_use]
+    pub fn from_repertoire(repertoire: &Repertoire) -> Self {
+        Self::from_moves(repertoire.moves().iter().cloned())
+    }
+
+    /// Builds a graph from an iterator of repertoire moves.
+    #[must_use]
+    pub fn from_moves<I>(moves: I) -> Self
+    where
+        I: IntoIterator<Item = RepertoireMove>,
+    {
+        let mut graph = Self::default();
+        for mv in moves {
+            let edge = OpeningEdge::new(
+                mv.edge_id,
+                mv.parent_id,
+                mv.child_id,
+                mv.move_uci,
+                mv.move_san,
+            );
+            graph.insert_edge(edge);
+        }
+        graph
+    }
+
+    /// Returns the edges that originate from the provided parent position.
+    #[must_use]
+    pub fn children(&self, position_id: u64) -> Vec<&OpeningEdge> {
+        self.outgoing
+            .get(&position_id)
+            .into_iter()
+            .flat_map(|edge_ids| edge_ids.iter())
+            .filter_map(|edge_id| self.edges.get(edge_id))
+            .collect()
+    }
+
+    /// Returns the edges that lead into the provided child position.
+    #[must_use]
+    pub fn parents(&self, position_id: u64) -> Vec<&OpeningEdge> {
+        self.incoming
+            .get(&position_id)
+            .into_iter()
+            .flat_map(|edge_ids| edge_ids.iter())
+            .filter_map(|edge_id| self.edges.get(edge_id))
+            .collect()
+    }
+
+    /// Returns the ordered path of edges from a root to the requested position, if it exists.
+    #[must_use]
+    pub fn path_to(&self, position_id: u64) -> Option<Vec<&OpeningEdge>> {
+        if !self.contains_position(position_id) {
+            return None;
+        }
+
+        let mut path = Vec::new();
+        let mut current = position_id;
+        let mut visited = HashSet::new();
+
+        while let Some(parents) = self.incoming.get(&current) {
+            if parents.is_empty() {
+                break;
+            }
+
+            // Follow the first recorded parent edge to maintain deterministic traversal.
+            let edge_id = parents[0];
+            let edge = self.edges.get(&edge_id)?;
+
+            if !visited.insert(current) {
+                // Cycle detected; abort rather than looping forever.
+                return None;
+            }
+
+            path.push(edge);
+            current = edge.parent_id;
+        }
+
+        path.reverse();
+        Some(path)
+    }
+
+    fn contains_position(&self, position_id: u64) -> bool {
+        self.outgoing.contains_key(&position_id)
+            || self.incoming.contains_key(&position_id)
+            || self
+                .edges
+                .values()
+                .any(|edge| edge.parent_id == position_id || edge.child_id == position_id)
+    }
+
+    fn insert_edge(&mut self, edge: OpeningEdge) {
+        if self.edges.contains_key(&edge.id) {
+            return;
+        }
+
+        self.outgoing
+            .entry(edge.parent_id)
+            .or_default()
+            .push(edge.id);
+        self.incoming
+            .entry(edge.child_id)
+            .or_default()
+            .push(edge.id);
+        self.edges.insert(edge.id, edge);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_moves() -> Vec<RepertoireMove> {
+        vec![
+            RepertoireMove::new(1, 10, 20, "e2e4", "e4"),
+            RepertoireMove::new(2, 10, 30, "d2d4", "d4"),
+            RepertoireMove::new(3, 20, 40, "g1f3", "Nf3"),
+        ]
+    }
+
+    #[test]
+    fn children_returns_edges_for_parent() {
+        let repertoire = Repertoire::from_iter(sample_moves().clone());
+        let graph = OpeningGraph::from_repertoire(&repertoire);
+
+        let children = graph.children(10);
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].id, 1);
+        assert_eq!(children[1].id, 2);
+    }
+
+    #[test]
+    fn parents_returns_edges_for_child() {
+        let graph = OpeningGraph::from_moves(sample_moves());
+
+        let parents = graph.parents(40);
+        assert_eq!(parents.len(), 1);
+        assert_eq!(parents[0].id, 3);
+    }
+
+    #[test]
+    fn path_to_collects_route_from_root() {
+        let graph = OpeningGraph::from_moves(sample_moves());
+
+        let path = graph.path_to(40).expect("path exists");
+        let ids: Vec<u64> = path.iter().map(|edge| edge.id).collect();
+        assert_eq!(ids, vec![1, 3]);
+    }
+
+    #[test]
+    fn unknown_position_has_no_path() {
+        let graph = OpeningGraph::from_moves(sample_moves());
+        assert!(graph.path_to(999).is_none());
+        assert!(graph.children(999).is_empty());
+        assert!(graph.parents(999).is_empty());
+    }
+
+    #[test]
+    fn root_position_has_empty_path() {
+        let graph = OpeningGraph::from_moves(sample_moves());
+        let path = graph.path_to(10).expect("root exists");
+        assert!(path.is_empty());
+    }
+}

--- a/crates/review-domain/src/opening/mod.rs
+++ b/crates/review-domain/src/opening/mod.rs
@@ -3,7 +3,9 @@
 mod card;
 mod edge;
 mod edge_input;
+mod graph;
 
 pub use card::OpeningCard;
 pub use edge::OpeningEdge;
 pub use edge_input::EdgeInput;
+pub use graph::OpeningGraph;

--- a/web-ui/src/application/controllers/OpeningReviewController.ts
+++ b/web-ui/src/application/controllers/OpeningReviewController.ts
@@ -31,12 +31,14 @@ export type OpeningReviewEvent =
   | { type: 'status'; status: OpeningReviewStatus }
   | { type: 'error'; message: string };
 
-export interface OpeningReviewController {
-  getSnapshot(): OpeningReviewSnapshot;
-  selectSquare(square: string): void;
-  dropPiece(from: string, to: string): void;
-  submitGrade(grade: ReviewGrade): Promise<void>;
-  loadLine(lineId: string): Promise<void>;
-  reset(): void;
-  subscribe(listener: (snapshot: OpeningReviewSnapshot, event?: OpeningReviewEvent) => void): () => void;
-}
+export type OpeningReviewController = {
+  getSnapshot: () => OpeningReviewSnapshot;
+  selectSquare: (square: string) => void;
+  dropPiece: (from: string, to: string) => void;
+  submitGrade: (grade: ReviewGrade) => Promise<void>;
+  loadLine: (lineId: string) => Promise<void>;
+  reset: () => void;
+  subscribe: (
+    listener: (snapshot: OpeningReviewSnapshot, event?: OpeningReviewEvent) => void,
+  ) => () => void;
+};

--- a/web-ui/src/application/controllers/SessionController.ts
+++ b/web-ui/src/application/controllers/SessionController.ts
@@ -1,8 +1,4 @@
-import type {
-  CardSummary,
-  ReviewGrade,
-  SessionStats,
-} from '../../types/gateway';
+import type { CardSummary, ReviewGrade, SessionStats } from '../../types/gateway';
 
 export type SessionStatus =
   | 'idle'
@@ -22,12 +18,12 @@ export type SessionSnapshot = {
   error?: string;
 };
 
-export interface SessionController {
-  getSnapshot(): SessionSnapshot;
-  subscribe(listener: (snapshot: SessionSnapshot) => void): () => void;
-  start(): Promise<void>;
-  startDemo(): Promise<void>;
-  submitGrade(grade: ReviewGrade, latencyMs: number): Promise<void>;
-  preloadNext(): Promise<void>;
-  reset(): void;
-}
+export type SessionController = {
+  getSnapshot: () => SessionSnapshot;
+  subscribe: (listener: (snapshot: SessionSnapshot) => void) => () => void;
+  start: () => Promise<void>;
+  startDemo: () => Promise<void>;
+  submitGrade: (grade: ReviewGrade, latencyMs: number) => Promise<void>;
+  preloadNext: () => Promise<void>;
+  reset: () => void;
+};

--- a/web-ui/src/application/services/CommandPaletteService.ts
+++ b/web-ui/src/application/services/CommandPaletteService.ts
@@ -20,13 +20,13 @@ export type CommandExecution = {
 
 export type CommandHandler = (
   context: CommandContext,
-) => Promise<CommandExecution | void> | CommandExecution | void;
+) => Promise<CommandExecution | undefined> | CommandExecution | undefined;
 
-export interface CommandPaletteService {
-  register(command: CommandRegistration, handler: CommandHandler): void;
-  unregister(commandId: string): void;
-  list(): CommandRegistration[];
-  execute(commandId: string, context?: Partial<CommandContext>): Promise<CommandExecution>;
-  subscribe(listener: (execution: CommandExecution) => void): () => void;
-  reset(): void;
-}
+export type CommandPaletteService = {
+  register: (command: CommandRegistration, handler: CommandHandler) => void;
+  unregister: (commandId: string) => void;
+  list: () => CommandRegistration[];
+  execute: (commandId: string, context?: Partial<CommandContext>) => Promise<CommandExecution>;
+  subscribe: (listener: (execution: CommandExecution) => void) => () => void;
+  reset: () => void;
+};

--- a/web-ui/src/application/services/ImportPlanner.ts
+++ b/web-ui/src/application/services/ImportPlanner.ts
@@ -1,7 +1,4 @@
-import type {
-  DetectedOpeningLine,
-  ScheduledOpeningLine,
-} from '../../types/repertoire';
+import type { DetectedOpeningLine, ScheduledOpeningLine } from '../../types/repertoire';
 
 export type ImportPlan = {
   line: ScheduledOpeningLine;
@@ -9,8 +6,8 @@ export type ImportPlan = {
   messages: string[];
 };
 
-export interface ImportPlanner {
-  planLine(line: DetectedOpeningLine, referenceDate?: Date): ImportPlan;
-  planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[];
-  persist(plan: ImportPlan): Promise<void>;
-}
+export type ImportPlanner = {
+  planLine: (line: DetectedOpeningLine, referenceDate?: Date) => ImportPlan;
+  planBulk: (lines: DetectedOpeningLine[], referenceDate?: Date) => ImportPlan[];
+  persist: (plan: ImportPlan) => Promise<void>;
+};

--- a/web-ui/src/application/services/PgnImportService.ts
+++ b/web-ui/src/application/services/PgnImportService.ts
@@ -1,7 +1,4 @@
-import type {
-  DetectedOpeningLine,
-  ScheduledOpeningLine,
-} from '../../types/repertoire';
+import type { DetectedOpeningLine, ScheduledOpeningLine } from '../../types/repertoire';
 
 export type PgnImportSource = {
   kind: 'text' | 'file';
@@ -28,8 +25,8 @@ export type PgnImportOutcome = {
   errors: string[];
 };
 
-export interface PgnImportService {
-  detect(source: PgnImportSource): Promise<PgnImportOutcome>;
-  acknowledge(outcome: PgnImportOutcome): void;
-  clear(): void;
-}
+export type PgnImportService = {
+  detect: (source: PgnImportSource) => Promise<PgnImportOutcome>;
+  acknowledge: (outcome: PgnImportOutcome) => void;
+  clear: () => void;
+};

--- a/web-ui/src/application/viewModels/DashboardViewModel.ts
+++ b/web-ui/src/application/viewModels/DashboardViewModel.ts
@@ -29,10 +29,10 @@ export type DashboardOverview = {
   stats: SessionStats | null;
 };
 
-export interface DashboardViewModel {
-  load(): Promise<DashboardOverview>;
-  refresh(): Promise<DashboardOverview>;
-  subscribe(listener: (overview: DashboardOverview) => void): () => void;
-  applyImportResults(results: ImportResult[]): void;
-  updateSessionStats(stats: SessionStats): void;
-}
+export type DashboardViewModel = {
+  load: () => Promise<DashboardOverview>;
+  refresh: () => Promise<DashboardOverview>;
+  subscribe: (listener: (overview: DashboardOverview) => void) => () => void;
+  applyImportResults: (results: ImportResult[]) => void;
+  updateSessionStats: (stats: SessionStats) => void;
+};


### PR DESCRIPTION
## Summary
- add an OpeningGraph adjacency structure with traversal helpers and unit tests in review-domain
- cover the graph via card-store and chess-training-pgn-import integration tests
- convert application-layer TypeScript interfaces into type aliases for lint compliance

## Testing
- cargo test -p review-domain
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ebff0466908325b05c53deefbae93f