### PR TITLE
Align session controller with gateway session identifiers

### DIFF
--- a/web-ui/src/application/controllers/GatewaySessionController.ts
+++ b/web-ui/src/application/controllers/GatewaySessionController.ts
@@ -1,0 +1,145 @@
+import type {
+  CardSummary,
+  ReviewGrade,
+  SessionStats,
+  StartSessionResponse,
+} from '../../types/gateway';
+import type { SessionController, SessionSnapshot } from './SessionController';
+
+export type SessionGateway = {
+  startSession(userId: string): Promise<StartSessionResponse>;
+  grade(
+    sessionId: string,
+    cardId: string,
+    gradeValue: ReviewGrade,
+    latencyMs: number,
+  ): Promise<{ next_card?: CardSummary; stats?: SessionStats }>;
+  stats(sessionId: string): Promise<SessionStats>;
+};
+
+const IDLE_SNAPSHOT: SessionSnapshot = {
+  status: 'idle',
+  queueSize: 0,
+  currentCard: undefined,
+  sessionId: undefined,
+  stats: undefined,
+  lastGrade: undefined,
+  error: undefined,
+};
+
+const unknownError = (message: string, cause: unknown): string => {
+  if (cause instanceof Error) {
+    return `${message}: ${cause.message}`;
+  }
+  return message;
+};
+
+export class GatewaySessionController implements SessionController {
+  private readonly gateway: SessionGateway;
+
+  private snapshot: SessionSnapshot = { ...IDLE_SNAPSHOT };
+
+  private listeners = new Set<(snapshot: SessionSnapshot) => void>();
+
+  public constructor(gateway: SessionGateway) {
+    this.gateway = gateway;
+  }
+
+  public getSnapshot(): SessionSnapshot {
+    return this.snapshot;
+  }
+
+  public subscribe(listener: (snapshot: SessionSnapshot) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public async start(userId: string): Promise<void> {
+    await this.startInternal(userId);
+  }
+
+  public async startDemo(): Promise<void> {
+    await this.startInternal('demo-user');
+  }
+
+  public async submitGrade(grade: ReviewGrade, latencyMs: number): Promise<void> {
+    const { currentCard, sessionId } = this.snapshot;
+    if (!currentCard || !sessionId) {
+      return;
+    }
+
+    this.updateSnapshot({ status: 'submittingGrade', lastGrade: grade, error: undefined });
+
+    try {
+      const response = await this.gateway.grade(sessionId, currentCard.card_id, grade, latencyMs);
+      const stats =
+        response.stats ?? (await this.safeLoadStats(sessionId)) ?? this.snapshot.stats;
+
+      this.updateSnapshot({
+        status: 'active',
+        currentCard: response.next_card,
+        stats,
+      });
+    } catch (error) {
+      this.updateSnapshot({
+        status: 'error',
+        error: unknownError('Failed to submit grade', error),
+      });
+    }
+  }
+
+  public async preloadNext(): Promise<void> {
+    // Future implementation can trigger background fetches.
+    return Promise.resolve();
+  }
+
+  public reset(): void {
+    this.updateSnapshot({ ...IDLE_SNAPSHOT });
+  }
+
+  private async startInternal(userId: string): Promise<void> {
+    this.updateSnapshot({ status: 'loading', error: undefined });
+
+    try {
+      const session = await this.gateway.startSession(userId);
+
+      this.updateSnapshot({
+        status: 'active',
+        sessionId: session.session_id,
+        currentCard: session.first_card,
+        queueSize: session.queue_size,
+        stats: undefined,
+      });
+
+      const stats = await this.safeLoadStats(session.session_id);
+      if (stats) {
+        this.updateSnapshot({ stats });
+      }
+    } catch (error) {
+      this.updateSnapshot({
+        status: 'error',
+        error: unknownError('Failed to start session', error),
+      });
+    }
+  }
+
+  private async safeLoadStats(sessionId: string): Promise<SessionStats | undefined> {
+    try {
+      return await this.gateway.stats(sessionId);
+    } catch (error) {
+      this.updateSnapshot({
+        error: unknownError('Failed to load session stats', error),
+      });
+      return undefined;
+    }
+  }
+
+  private updateSnapshot(patch: Partial<SessionSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...patch };
+    for (const listener of this.listeners) {
+      listener(this.snapshot);
+    }
+  }
+}

--- a/web-ui/src/application/controllers/__tests__/GatewaySessionController.test.ts
+++ b/web-ui/src/application/controllers/__tests__/GatewaySessionController.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CardSummary, SessionStats, StartSessionResponse } from '../../../types/gateway';
+import { GatewaySessionController, type SessionGateway } from '../GatewaySessionController';
+
+describe('GatewaySessionController', () => {
+  const gateway = {
+    startSession: vi.fn<Parameters<SessionGateway['startSession']>, ReturnType<SessionGateway['startSession']>>(),
+    grade: vi.fn<Parameters<SessionGateway['grade']>, ReturnType<SessionGateway['grade']>>(),
+    stats: vi.fn<Parameters<SessionGateway['stats']>, ReturnType<SessionGateway['stats']>>(),
+  };
+
+  const stubCard: CardSummary = {
+    card_id: 'card-1',
+    kind: 'Opening',
+    position_fen: 'start',
+    prompt: 'Play the best move',
+  };
+
+  const stubStats: SessionStats = {
+    reviews_today: 0,
+    accuracy: 0.8,
+    avg_latency_ms: 1500,
+    due_count: 10,
+    completed_count: 2,
+  };
+
+  let controller: GatewaySessionController;
+
+  beforeEach(() => {
+    gateway.startSession.mockReset();
+    gateway.grade.mockReset();
+    gateway.stats.mockReset();
+
+    controller = new GatewaySessionController(gateway as unknown as SessionGateway);
+  });
+
+  it('starts a demo session, loads stats, and emits a snapshot', async () => {
+    const response: StartSessionResponse = {
+      session_id: 'session-1',
+      queue_size: 3,
+      first_card: stubCard,
+    };
+    gateway.startSession.mockResolvedValue(response);
+    gateway.stats.mockResolvedValue(stubStats);
+
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    await controller.startDemo();
+
+    expect(gateway.startSession).toHaveBeenCalledWith('demo-user');
+    expect(gateway.stats).toHaveBeenCalledWith('session-1');
+
+    const snapshot = controller.getSnapshot();
+    expect(snapshot.sessionId).toBe('session-1');
+    expect(snapshot.currentCard).toEqual(stubCard);
+    expect(snapshot.stats).toEqual(stubStats);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ currentCard: stubCard }));
+  });
+
+  it('submits a grade and advances to the next card', async () => {
+    gateway.startSession.mockResolvedValue({
+      session_id: 'session-1',
+      queue_size: 3,
+      first_card: stubCard,
+    });
+    gateway.stats.mockResolvedValue(stubStats);
+
+    await controller.startDemo();
+
+    const nextCard: CardSummary = { ...stubCard, card_id: 'card-2' };
+    gateway.grade.mockResolvedValue({ next_card: nextCard, stats: { ...stubStats, completed_count: 3 } });
+    gateway.stats.mockResolvedValue(stubStats);
+
+    await controller.submitGrade('Good', 2500);
+
+    expect(gateway.grade).toHaveBeenCalledWith('session-1', 'card-1', 'Good', 2500);
+    expect(controller.getSnapshot().currentCard).toEqual(nextCard);
+    expect(controller.getSnapshot().stats?.completed_count).toBe(3);
+    expect(gateway.stats).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores grade submissions when no current card is active', async () => {
+    await controller.submitGrade('Good', 1200);
+
+    expect(gateway.grade).not.toHaveBeenCalled();
+  });
+
+  it('allows subscribers to unsubscribe', async () => {
+    const listener = vi.fn();
+    const unsubscribe = controller.subscribe(listener);
+
+    await controller.startDemo();
+    listener.mockClear();
+
+    unsubscribe();
+    controller.reset();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/src/clients/__tests__/sessionGateway.test.ts
+++ b/web-ui/src/clients/__tests__/sessionGateway.test.ts
@@ -62,13 +62,14 @@ describe('sessionGateway', () => {
       }),
     );
 
-    const result = await sessionGateway.grade('c1', 'Good', 4500);
+    const result = await sessionGateway.grade('session-123', 'c1', 'Good', 4500);
 
     expect(fetchMock).toHaveBeenCalledWith(
       'http://localhost:3000/api/session/grade',
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
+          session_id: 'session-123',
           card_id: 'c1',
           grade: 'Good',
           latency_ms: 4500,
@@ -101,10 +102,10 @@ describe('sessionGateway', () => {
       }),
     );
 
-    const result = await sessionGateway.stats();
+    const result = await sessionGateway.stats('session-123');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'http://localhost:3000/api/session/stats',
+      'http://localhost:3000/api/session/stats?session_id=session-123',
       expect.objectContaining({ method: 'GET' }),
     );
     expect(result).toEqual(responseBody);
@@ -113,6 +114,8 @@ describe('sessionGateway', () => {
   it('throws when stats fails', async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
 
-    await expect(sessionGateway.stats()).rejects.toThrow('/api/session/stats failed: 404');
+    await expect(sessionGateway.stats('session-123')).rejects.toThrow(
+      '/api/session/stats?session_id=session-123 failed: 404',
+    );
   });
 });

--- a/web-ui/src/clients/sessionGateway.ts
+++ b/web-ui/src/clients/sessionGateway.ts
@@ -60,6 +60,11 @@ function normalizeConfig(init: RequestConfigWithBody): RequestInit {
   } satisfies RequestInit;
 }
 
+const buildStatsPath = (sessionId: string): string => {
+  const params = new URLSearchParams({ session_id: sessionId });
+  return `/api/session/stats?${params.toString()}`;
+};
+
 export const sessionGateway = {
   startSession(userId: string): Promise<StartSessionResponse> {
     return request<StartSessionResponse>('/api/session/start', {
@@ -68,16 +73,22 @@ export const sessionGateway = {
     });
   },
   grade(
+    sessionId: string,
     cardId: string,
     gradeValue: ReviewGrade,
     latencyMs: number,
-  ): Promise<{ next_card?: CardSummary }> {
-    return request<{ next_card?: CardSummary }>('/api/session/grade', {
+  ): Promise<{ next_card?: CardSummary; stats?: SessionStats }> {
+    return request<{ next_card?: CardSummary; stats?: SessionStats }>('/api/session/grade', {
       method: 'POST',
-      body: { card_id: cardId, grade: gradeValue, latency_ms: latencyMs },
+      body: {
+        session_id: sessionId,
+        card_id: cardId,
+        grade: gradeValue,
+        latency_ms: latencyMs,
+      },
     });
   },
-  stats(): Promise<SessionStats> {
-    return request<SessionStats>('/api/session/stats', { method: 'GET' });
+  stats(sessionId: string): Promise<SessionStats> {
+    return request<SessionStats>(buildStatsPath(sessionId), { method: 'GET' });
   },
 } as const;


### PR DESCRIPTION
## Summary
- include the session identifier when grading cards and fetching stats from the session gateway client
- update GatewaySessionController to persist the session id, reuse grade responses, and fall back to refreshed stats when needed
- extend the controller and client unit tests to exercise the new contract expectations

## Testing
- npm run test -- src/clients/__tests__/sessionGateway.test.ts
- npm run test -- src/application/controllers/__tests__/GatewaySessionController.test.ts
- npm run test
- npm run lint *(fails: pre-existing repository lint violations)*
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ebfe2870ec8325a7f200451a1d8bf2