### PR TITLE
Emit initial dashboard overview on subscription

### DIFF
--- a/web-ui/src/application/viewModels/DashboardViewModel.ts
+++ b/web-ui/src/application/viewModels/DashboardViewModel.ts
@@ -1,5 +1,11 @@
 import type { SessionStats } from '../../types/gateway';
 import type { ImportResult, ScheduledOpeningLine } from '../../types/repertoire';
+import { formatUnlockDate as defaultFormatUnlockDate } from '../../utils/formatUnlockDate';
+import type {
+  ReviewOverview,
+  ReviewSnapshot,
+} from '../../services/ReviewPlanner';
+import { ReviewPlanner } from '../../services/ReviewPlanner';
 
 export type DashboardMetric = {
   id: string;
@@ -17,22 +23,299 @@ export type DashboardBadge = {
 };
 
 export type UpcomingUnlock = {
-  line: ScheduledOpeningLine;
+  id: string;
+  title: string;
+  description: string;
+  scheduledFor: string;
   friendlyDate: string;
+  source: 'baseline' | 'imported';
+  line?: ScheduledOpeningLine;
 };
 
 export type DashboardOverview = {
   metrics: DashboardMetric[];
   badge: DashboardBadge | null;
+  accuracyBadge: DashboardBadge | null;
   upcomingUnlocks: UpcomingUnlock[];
   importResults: ImportResult[];
   stats: SessionStats | null;
+  recommendation: ReviewOverview['recommendation'];
 };
 
 export interface DashboardViewModel {
   load(): Promise<DashboardOverview>;
   refresh(): Promise<DashboardOverview>;
+  getCurrentOverview(): DashboardOverview;
   subscribe(listener: (overview: DashboardOverview) => void): () => void;
   applyImportResults(results: ImportResult[]): void;
-  updateSessionStats(stats: SessionStats): void;
+  updateSessionStats(stats: SessionStats | null): void;
+}
+
+export type DashboardViewModelDependencies = {
+  reviewPlanner: ReviewPlanner;
+  baselineSnapshot: ReviewSnapshot;
+  formatUnlockDate?: (input: string) => string;
+};
+
+type Listener = (overview: DashboardOverview) => void;
+
+const BACKLOG_BADGE_MAP = {
+  cleared: {
+    tone: 'success',
+    title: 'Cleared',
+    description: 'Queue fully cleared — add a new line today',
+  },
+  low: {
+    tone: 'success',
+    title: 'Low backlog',
+    description: 'Finish the remaining reviews in a single sprint',
+  },
+  moderate: {
+    tone: 'warning',
+    title: 'Moderate backlog',
+    description: 'Work through reviews in two focused blocks',
+  },
+  high: {
+    tone: 'danger',
+    title: 'High backlog',
+    description: 'Catch up on overdue reviews as the top priority',
+  },
+} as const;
+
+const ACCURACY_BADGE_MAP = {
+  stable: {
+    tone: 'success',
+    title: 'Accuracy stable',
+    description: 'Keep reinforcing strengths with light review',
+  },
+  watch: {
+    tone: 'warning',
+    title: 'Accuracy watch',
+    description: 'Reinforce recent mistakes to steady accuracy',
+  },
+  critical: {
+    tone: 'danger',
+    title: 'Accuracy critical',
+    description: 'Rebuild confidence on the weakest variations',
+  },
+} as const;
+
+const COMPLETION_TONE_MAP = {
+  stable: 'success',
+  watch: 'warning',
+  critical: 'danger',
+} as const satisfies Record<keyof typeof ACCURACY_BADGE_MAP, DashboardMetric['tone']>;
+
+export class DefaultDashboardViewModel implements DashboardViewModel {
+  private readonly reviewPlanner: ReviewPlanner;
+  private readonly baselineSnapshot: ReviewSnapshot;
+  private readonly formatUnlockDate: (input: string) => string;
+
+  private stats: SessionStats | null = null;
+  private importResults: ImportResult[] = [];
+  private readonly plannedLines = new Map<string, ScheduledOpeningLine>();
+  private readonly listeners = new Set<Listener>();
+  private currentOverview: DashboardOverview | null = null;
+
+  constructor({
+    reviewPlanner,
+    baselineSnapshot,
+    formatUnlockDate = defaultFormatUnlockDate,
+  }: DashboardViewModelDependencies) {
+    this.reviewPlanner = reviewPlanner;
+    this.baselineSnapshot = { ...baselineSnapshot };
+    this.formatUnlockDate = formatUnlockDate;
+    this.currentOverview = this.composeOverview();
+  }
+
+  public async load(): Promise<DashboardOverview> {
+    if (!this.currentOverview) {
+      this.currentOverview = this.composeOverview();
+    }
+    return this.currentOverview;
+  }
+
+  public async refresh(): Promise<DashboardOverview> {
+    this.currentOverview = this.composeOverview();
+    return this.currentOverview;
+  }
+
+  public getCurrentOverview(): DashboardOverview {
+    if (!this.currentOverview) {
+      this.currentOverview = this.composeOverview();
+    }
+    return this.currentOverview;
+  }
+
+  public subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.getCurrentOverview());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public applyImportResults(results: ImportResult[]): void {
+    if (results.length === 0) {
+      return;
+    }
+
+    this.importResults = [...this.importResults, ...results];
+    results.forEach((result) => {
+      this.plannedLines.set(result.line.id, result.line);
+    });
+
+    this.emit();
+  }
+
+  public updateSessionStats(stats: SessionStats | null): void {
+    this.stats = stats;
+    this.emit();
+  }
+
+  private emit(): void {
+    const overview = this.composeOverview();
+    this.currentOverview = overview;
+    this.listeners.forEach((listener) => listener(overview));
+  }
+
+  private composeOverview(): DashboardOverview {
+    const snapshot = this.composeSnapshot();
+    const reviewOverview = this.reviewPlanner.buildOverview(snapshot);
+
+    const metrics = this.buildMetrics(reviewOverview);
+    const badge = this.buildBacklogBadge(reviewOverview);
+    const accuracyBadge = this.buildAccuracyBadge(reviewOverview);
+    const upcomingUnlocks = this.buildUpcomingUnlocks(reviewOverview);
+
+    return {
+      metrics,
+      badge,
+      accuracyBadge,
+      upcomingUnlocks,
+      importResults: this.importResults,
+      stats: this.stats,
+      recommendation: reviewOverview.recommendation,
+    };
+  }
+
+  private composeSnapshot(): ReviewSnapshot {
+    const upcomingUnlocks = [
+      ...this.baselineSnapshot.upcomingUnlocks,
+      ...Array.from(this.plannedLines.values()).map((line) => ({
+        id: line.id,
+        move: `${line.opening} (${line.color})`,
+        idea: `Line: ${line.display}`,
+        scheduledFor: line.scheduledFor,
+      })),
+    ];
+
+    if (!this.stats) {
+      return {
+        ...this.baselineSnapshot,
+        upcomingUnlocks,
+      };
+    }
+
+    return {
+      dueCards: this.stats.due_count,
+      completedCards: this.stats.completed_count,
+      accuracyRate: this.stats.accuracy,
+      streakLength: this.baselineSnapshot.streakLength,
+      upcomingUnlocks,
+    };
+  }
+
+  private buildMetrics(overview: ReviewOverview): DashboardMetric[] {
+    const {
+      totalDue,
+      completedToday,
+      remaining,
+      completionRate,
+      accuracyRate,
+    } = overview.progress;
+    const accuracyBadge = overview.tension.accuracyRisk;
+
+    const completionPercentage = Math.round(completionRate * 100);
+    const accuracyPercentage = Math.round(accuracyRate * 100);
+
+    return [
+      {
+        id: 'due-today',
+        label: 'Due Today',
+        value: String(totalDue),
+        tone: 'default',
+      },
+      {
+        id: 'completed-today',
+        label: 'Completed',
+        value: String(completedToday),
+        tone: 'success',
+      },
+      {
+        id: 'remaining',
+        label: 'Remaining',
+        value: String(remaining),
+        tone: remaining === 0 ? 'success' : 'warning',
+      },
+      {
+        id: 'completion-rate',
+        label: 'Completion',
+        value: `${completionPercentage}% complete`,
+        helperText: `Accuracy ${accuracyPercentage}%`,
+        tone: COMPLETION_TONE_MAP[accuracyBadge],
+      },
+    ];
+  }
+
+  private buildBacklogBadge(overview: ReviewOverview): DashboardBadge {
+    const tension = overview.tension.backlogPressure;
+    const definition = BACKLOG_BADGE_MAP[tension];
+
+    return {
+      id: 'backlog-status',
+      tone: definition.tone,
+      title: definition.title,
+      description: definition.description,
+    };
+  }
+
+  private buildAccuracyBadge(overview: ReviewOverview): DashboardBadge {
+    const risk = overview.tension.accuracyRisk;
+    const definition = ACCURACY_BADGE_MAP[risk];
+
+    return {
+      id: 'accuracy-status',
+      tone: definition.tone,
+      title: definition.title,
+      description: definition.description,
+    };
+  }
+
+  private buildUpcomingUnlocks(overview: ReviewOverview): UpcomingUnlock[] {
+    return overview.upcomingUnlocks.map((unlock) => {
+      const plannedLine = this.plannedLines.get(unlock.id);
+
+      if (plannedLine) {
+        return {
+          id: plannedLine.id,
+          title: `${plannedLine.opening} (${plannedLine.color})`,
+          description: `Line: ${plannedLine.display}`,
+          scheduledFor: plannedLine.scheduledFor,
+          friendlyDate: this.formatUnlockDate(plannedLine.scheduledFor),
+          source: 'imported' as const,
+          line: plannedLine,
+        };
+      }
+
+      return {
+        id: unlock.id,
+        title: unlock.move,
+        description: unlock.idea,
+        scheduledFor: unlock.scheduledFor,
+        friendlyDate: this.formatUnlockDate(unlock.scheduledFor),
+        source: 'baseline' as const,
+      };
+    });
+  }
 }

--- a/web-ui/src/application/viewModels/__tests__/DashboardViewModel.test.ts
+++ b/web-ui/src/application/viewModels/__tests__/DashboardViewModel.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { DefaultDashboardViewModel } from '../DashboardViewModel.js';
+import { ReviewPlanner } from '../../../services/ReviewPlanner.js';
+import { sampleSnapshot } from '../../../fixtures/sampleSnapshot.js';
+import type { SessionStats } from '../../../types/gateway.js';
+import type { ImportResult, ScheduledOpeningLine } from '../../../types/repertoire.js';
+
+const formatUnlockDate = vi.fn((input: string) => `friendly-${input}`);
+
+const createViewModel = () =>
+  new DefaultDashboardViewModel({
+    reviewPlanner: new ReviewPlanner(),
+    baselineSnapshot: sampleSnapshot,
+    formatUnlockDate,
+  });
+
+describe('DefaultDashboardViewModel', () => {
+  beforeEach(() => {
+    formatUnlockDate.mockClear();
+  });
+
+  it('produces baseline metrics, badges, and unlock strings on load', async () => {
+    const viewModel = createViewModel();
+
+    const overview = await viewModel.load();
+
+    expect(overview.metrics).toEqual([
+      { id: 'due-today', label: 'Due Today', value: '18', tone: 'default' },
+      { id: 'completed-today', label: 'Completed', value: '11', tone: 'success' },
+      { id: 'remaining', label: 'Remaining', value: '7', tone: 'warning' },
+      {
+        id: 'completion-rate',
+        label: 'Completion',
+        value: '61% complete',
+        helperText: 'Accuracy 86%',
+        tone: 'warning',
+      },
+    ]);
+    expect(overview.badge).toEqual({
+      id: 'backlog-status',
+      tone: 'warning',
+      title: 'Moderate backlog',
+      description: 'Work through reviews in two focused blocks',
+    });
+    expect(overview.accuracyBadge).toEqual({
+      id: 'accuracy-status',
+      tone: 'warning',
+      title: 'Accuracy watch',
+      description: 'Reinforce recent mistakes to steady accuracy',
+    });
+    expect(overview.recommendation).toEqual({
+      primaryAction: "Work through today's reviews in two focused blocks",
+      secondaryAction: 'Log any mistakes immediately to revisit tomorrow',
+    });
+    expect(overview.upcomingUnlocks).toEqual([
+      {
+        id: 'unlock-italian',
+        title: 'Bc4',
+        description: 'Pressure f7 in the Italian Game',
+        scheduledFor: '2024-01-14',
+        friendlyDate: 'friendly-2024-01-14',
+        source: 'baseline',
+      },
+      {
+        id: 'unlock-scandi',
+        title: 'Qxd5',
+        description: 'Centralize the queen in the Scandinavian',
+        scheduledFor: '2024-01-15',
+        friendlyDate: 'friendly-2024-01-15',
+        source: 'baseline',
+      },
+      {
+        id: 'unlock-tactic',
+        title: 'Nxf7+',
+        description: 'Tactic: Greek gift sacrifice',
+        scheduledFor: '2024-01-16',
+        friendlyDate: 'friendly-2024-01-16',
+        source: 'baseline',
+      },
+    ]);
+  });
+
+  it('updates progress metrics and badges when session stats change', async () => {
+    const viewModel = createViewModel();
+    await viewModel.load();
+
+    const listener = vi.fn();
+    viewModel.subscribe(listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    const stats: SessionStats = {
+      reviews_today: 9,
+      accuracy: 0.72,
+      avg_latency_ms: 1800,
+      due_count: 12,
+      completed_count: 9,
+    };
+
+    viewModel.updateSessionStats(stats);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    const updatedOverview = listener.mock.calls[1][0];
+
+    expect(updatedOverview.metrics).toEqual([
+      { id: 'due-today', label: 'Due Today', value: '12', tone: 'default' },
+      { id: 'completed-today', label: 'Completed', value: '9', tone: 'success' },
+      { id: 'remaining', label: 'Remaining', value: '3', tone: 'warning' },
+      {
+        id: 'completion-rate',
+        label: 'Completion',
+        value: '75% complete',
+        helperText: 'Accuracy 72%',
+        tone: 'danger',
+      },
+    ]);
+    expect(updatedOverview.badge).toEqual({
+      id: 'backlog-status',
+      tone: 'success',
+      title: 'Low backlog',
+      description: 'Finish the remaining reviews in a single sprint',
+    });
+    expect(updatedOverview.accuracyBadge).toEqual({
+      id: 'accuracy-status',
+      tone: 'danger',
+      title: 'Accuracy critical',
+      description: 'Rebuild confidence on the weakest variations',
+    });
+    expect(updatedOverview.stats).toEqual(stats);
+
+    const refreshed = await viewModel.refresh();
+    expect(refreshed).toEqual(updatedOverview);
+  });
+
+  it('treats zero due counts as fully complete', async () => {
+    const viewModel = createViewModel();
+    await viewModel.load();
+
+    viewModel.updateSessionStats({
+      reviews_today: 0,
+      accuracy: 0.82,
+      avg_latency_ms: 0,
+      due_count: 0,
+      completed_count: 0,
+    });
+
+    const overview = await viewModel.refresh();
+    expect(overview.metrics).toEqual([
+      { id: 'due-today', label: 'Due Today', value: '0', tone: 'default' },
+      { id: 'completed-today', label: 'Completed', value: '0', tone: 'success' },
+      { id: 'remaining', label: 'Remaining', value: '0', tone: 'success' },
+      {
+        id: 'completion-rate',
+        label: 'Completion',
+        value: '100% complete',
+        helperText: 'Accuracy 82%',
+        tone: 'warning',
+      },
+    ]);
+  });
+
+  it('appends import results to upcoming unlocks with friendly dates', async () => {
+    const viewModel = createViewModel();
+    await viewModel.load();
+
+    const newLine: ScheduledOpeningLine = {
+      id: 'line-sicilian',
+      opening: 'Sicilian Defence',
+      color: 'Black',
+      moves: ['e4', 'c5', 'Nf3', 'd6'],
+      display: '1.e4 c5 2.Nf3 d6',
+      scheduledFor: '2024-02-01',
+    };
+    const results: ImportResult[] = [{ added: true, line: newLine }];
+
+    const notifications: unknown[] = [];
+    const unsubscribe = viewModel.subscribe((overview) => {
+      notifications.push(overview);
+    });
+
+    viewModel.applyImportResults(results);
+
+    const refreshed = await viewModel.refresh();
+
+    expect(refreshed.importResults).toEqual(results);
+    const appendedUnlock = refreshed.upcomingUnlocks.find((unlock) => unlock.id === newLine.id);
+    expect(appendedUnlock).toEqual({
+      id: 'line-sicilian',
+      title: 'Sicilian Defence (Black)',
+      description: 'Line: 1.e4 c5 2.Nf3 d6',
+      scheduledFor: '2024-02-01',
+      friendlyDate: 'friendly-2024-02-01',
+      source: 'imported',
+      line: newLine,
+    });
+    expect(formatUnlockDate).toHaveBeenCalledWith('2024-02-01');
+    expect(notifications).toHaveLength(2);
+
+    unsubscribe();
+    viewModel.applyImportResults(results);
+    expect(notifications).toHaveLength(2);
+  });
+
+  it('invokes listeners immediately with the latest overview on subscribe', () => {
+    const viewModel = createViewModel();
+
+    const listener = vi.fn();
+    const unsubscribe = viewModel.subscribe(listener);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toEqual(viewModel.getCurrentOverview());
+
+    unsubscribe();
+    viewModel.applyImportResults([
+      {
+        added: true,
+        line: {
+          id: 'line-queued',
+          opening: 'French Defence',
+          color: 'Black',
+          moves: ['e4', 'e6', 'd4', 'd5'],
+          display: '1.e4 e6 2.d4 d5',
+          scheduledFor: '2024-02-10',
+        },
+      },
+    ]);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- make `DefaultDashboardViewModel.subscribe` push the current overview to new listeners as soon as they attach
- update the dashboard view-model unit tests to reflect the eager notification and guard against post-unsubscribe emissions

## Testing
- npm test -- DashboardViewModel
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ebfe07e3e88325bfaacf536227b80f