### PR TITLE
Implement PGN import normalization service

### DIFF
--- a/web-ui/src/application/services/__tests__/createPgnImportService.spec.ts
+++ b/web-ui/src/application/services/__tests__/createPgnImportService.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type PgnImportOutcome,
+  type PgnImportService,
+  type PgnImportSource,
+} from '../PgnImportService.js';
+import { createPgnImportService } from '../createPgnImportService.js';
+
+type ServiceFactoryOptions = Parameters<typeof createPgnImportService>[0];
+
+const fixedNow = new Date('2025-01-20T00:00:00.000Z');
+const createService = (options: ServiceFactoryOptions = {}): PgnImportService => {
+  return createPgnImportService({
+    clock: () => fixedNow,
+    generateId: () => 'message-1',
+    ...options,
+  });
+};
+
+describe('createPgnImportService', () => {
+  const detect = async (
+    service: PgnImportService,
+    source: PgnImportSource,
+  ): Promise<PgnImportOutcome> => {
+    const outcome = await service.detect(source);
+    expect(outcome.preview).toBeDefined();
+    return outcome;
+  };
+
+  it('normalizes PGN text and detects the Danish Gambit', async () => {
+    const service = createService();
+    const source: PgnImportSource = {
+      kind: 'text',
+      value: ' 1. e4 e5 2. d4   exd4 3.c3 ',
+    };
+
+    const outcome = await detect(service, source);
+
+    expect(outcome.preview.normalizedPgn).toEqual('1.e4 e5 2.d4 exd4 3.c3');
+    expect(outcome.preview.detectedLines).toEqual([
+      {
+        opening: 'Danish Gambit',
+        color: 'White',
+        moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+        display: '1.e4 e5 2.d4 exd4 3.c3',
+      },
+    ]);
+    expect(outcome.preview.scheduledLines).toEqual([]);
+    expect(outcome.errors).toEqual([]);
+    expect(outcome.messages).toEqual([
+      {
+        id: 'message-1',
+        tone: 'info',
+        headline: 'Detected Danish Gambit (White)',
+        body: 'Line preview: 1.e4 e5 2.d4 exd4 3.c3',
+        dispatchAt: fixedNow,
+      },
+    ]);
+  });
+
+  it('reads PGN lines from Blob sources', async () => {
+    const service = createService();
+    const blob = {
+      text: vi.fn().mockResolvedValue('1.e4 e5 2.Nf3 Nc6'),
+    } as unknown as Blob;
+    const source: PgnImportSource = { kind: 'file', value: blob };
+
+    const outcome = await detect(service, source);
+
+    expect(outcome.preview.detectedLines).toEqual([
+      {
+        opening: "King's Knight Opening",
+        color: 'White',
+        moves: ['e4', 'e5', 'Nf3', 'Nc6'],
+        display: '1.e4 e5 2.Nf3 Nc6',
+      },
+    ]);
+    expect(blob.text).toHaveBeenCalledTimes(1);
+    expect(outcome.messages[0]).toMatchObject({
+      id: 'message-1',
+      tone: 'info',
+      headline: "Detected King's Knight Opening (White)",
+    });
+  });
+
+  it('reports an error when no known opening matches', async () => {
+    const service = createService();
+    const source: PgnImportSource = {
+      kind: 'text',
+      value: '1.d4 d5 2.c4 e6',
+    };
+
+    const outcome = await detect(service, source);
+
+    expect(outcome.preview.detectedLines).toEqual([]);
+    expect(outcome.errors).toEqual([
+      'No matching opening found for the provided PGN.',
+    ]);
+    expect(outcome.messages).toEqual([]);
+  });
+
+  it('reports an error when the PGN text does not contain moves', async () => {
+    const service = createService();
+    const outcome = await detect(service, { kind: 'text', value: '   ' });
+
+    expect(outcome.preview.normalizedPgn).toEqual('');
+    expect(outcome.preview.detectedLines).toEqual([]);
+    expect(outcome.errors).toEqual(['PGN source did not include any moves.']);
+  });
+});

--- a/web-ui/src/application/services/createPgnImportService.ts
+++ b/web-ui/src/application/services/createPgnImportService.ts
@@ -1,0 +1,218 @@
+import type {
+  PgnImportFeedbackMessage,
+  PgnImportOutcome,
+  PgnImportService,
+  PgnImportSource,
+} from './PgnImportService.js';
+import type { DetectedOpeningLine } from '../../types/repertoire.js';
+
+const DEFAULT_PATTERNS: ReadonlyArray<{
+  opening: string;
+  color: DetectedOpeningLine['color'];
+  moves: readonly string[];
+}> = [
+  {
+    opening: 'Danish Gambit',
+    color: 'White',
+    moves: ['e4', 'e5', 'd4', 'exd4', 'c3'],
+  },
+  {
+    opening: "King's Knight Opening",
+    color: 'White',
+    moves: ['e4', 'e5', 'Nf3'],
+  },
+];
+
+type Dependencies = {
+  clock?: () => Date;
+  generateId?: () => string;
+  patterns?: ReadonlyArray<{
+    opening: string;
+    color: DetectedOpeningLine['color'];
+    moves: readonly string[];
+  }>;
+};
+
+const sanitizeMoves = (input: string): string[] =>
+  input
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .map((token) => token.trim())
+    .map((token) => token.replace(/^[0-9]+\.\.\./, ''))
+    .map((token) => token.replace(/^[0-9]+\./, ''))
+    .map((token) => token.replace(/[?!+#]/g, ''))
+    .filter((token) => token.length > 0);
+
+const formatMoveSequence = (moves: string[]): string => {
+  const segments: string[] = [];
+  for (let index = 0; index < moves.length; index += 2) {
+    const moveNumber = Math.floor(index / 2) + 1;
+    const whiteMove = moves[index];
+    const blackMove = moves[index + 1];
+    if (whiteMove) {
+      segments.push(`${String(moveNumber)}.${whiteMove}`);
+    }
+    if (blackMove) {
+      segments.push(blackMove);
+    }
+  }
+  return segments.join(' ');
+};
+
+const detectOpening = (
+  moves: string[],
+  patterns: ReadonlyArray<{
+    opening: string;
+    color: DetectedOpeningLine['color'];
+    moves: readonly string[];
+  }>,
+): DetectedOpeningLine | undefined => {
+  if (moves.length === 0) {
+    return undefined;
+  }
+
+  const normalized = moves.map((move) => move.toLowerCase());
+  const matched = patterns.find((pattern) => {
+    if (normalized.length < pattern.moves.length) {
+      return false;
+    }
+
+    return pattern.moves.every((expectedMove, index) => {
+      return normalized[index] === expectedMove.toLowerCase();
+    });
+  });
+
+  if (!matched) {
+    return undefined;
+  }
+
+  return {
+    opening: matched.opening,
+    color: matched.color,
+    moves: [...moves],
+    display: formatMoveSequence(moves),
+  } satisfies DetectedOpeningLine;
+};
+
+const readSource = async (source: PgnImportSource): Promise<string> => {
+  if (source.kind === 'text') {
+    return String(source.value ?? '');
+  }
+
+  const blobLike = source.value as Blob;
+  if (blobLike && typeof blobLike.text === 'function') {
+    return blobLike.text();
+  }
+
+  if (blobLike && typeof blobLike.arrayBuffer === 'function') {
+    const buffer = await blobLike.arrayBuffer();
+    return new TextDecoder().decode(buffer);
+  }
+
+  if (typeof Response !== 'undefined') {
+    try {
+      const response = new Response(blobLike as BodyInit);
+      return await response.text();
+    } catch (error) {
+      console.warn('PgnImportService: failed to decode blob source', error);
+    }
+  }
+
+  return String(blobLike ?? '');
+};
+
+const buildSuccessMessage = (
+  line: DetectedOpeningLine,
+  clock: () => Date,
+  generateId: () => string,
+): PgnImportFeedbackMessage => ({
+  id: generateId(),
+  tone: 'info',
+  headline: `Detected ${line.opening} (${line.color})`,
+  body: `Line preview: ${line.display}`,
+  dispatchAt: clock(),
+});
+
+const emptyOutcome: PgnImportOutcome = {
+  preview: {
+    normalizedPgn: '',
+    detectedLines: [],
+    scheduledLines: [],
+  },
+  messages: [],
+  errors: [],
+};
+
+export const createPgnImportService = (
+  dependencies: Dependencies = {},
+): PgnImportService => {
+  const {
+    clock = () => new Date(),
+    generateId = () => (typeof crypto !== 'undefined' ? crypto.randomUUID() : Math.random().toString(36).slice(2)),
+    patterns = DEFAULT_PATTERNS,
+  } = dependencies;
+
+  const pendingMessages = new Map<string, PgnImportFeedbackMessage>();
+
+  const buildOutcome = (outcome: PgnImportOutcome): PgnImportOutcome => {
+    pendingMessages.clear();
+    outcome.messages.forEach((message) => {
+      pendingMessages.set(message.id, message);
+    });
+    return outcome;
+  };
+
+  return {
+    async detect(source) {
+      const raw = (await readSource(source)).trim();
+      if (raw.length === 0) {
+        return buildOutcome({
+          ...emptyOutcome,
+          errors: ['PGN source did not include any moves.'],
+        });
+      }
+
+      const moves = sanitizeMoves(raw);
+      if (moves.length === 0) {
+        return buildOutcome({
+          ...emptyOutcome,
+          errors: ['PGN source did not include any moves.'],
+        });
+      }
+
+      const normalizedPgn = formatMoveSequence(moves);
+      const detected = detectOpening(moves, patterns);
+
+      if (!detected) {
+        return buildOutcome({
+          preview: {
+            normalizedPgn,
+            detectedLines: [],
+            scheduledLines: [],
+          },
+          messages: [],
+          errors: ['No matching opening found for the provided PGN.'],
+        });
+      }
+
+      const message = buildSuccessMessage(detected, clock, generateId);
+      return buildOutcome({
+        preview: {
+          normalizedPgn,
+          detectedLines: [detected],
+          scheduledLines: [],
+        },
+        messages: [message],
+        errors: [],
+      });
+    },
+    acknowledge(outcome) {
+      outcome.messages.forEach((message) => {
+        pendingMessages.delete(message.id);
+      });
+    },
+    clear() {
+      pendingMessages.clear();
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- add a `createPgnImportService` factory that normalizes PGN sources, matches opening patterns, and generates feedback messages
- cover the service with vitest specs for Danish Gambit detection, blob inputs, and error messaging edge cases

## Testing
- npm test --prefix web-ui

------
https://chatgpt.com/codex/tasks/task_e_68ebfee7a54483258cdc37bda60b22ee