### PR TITLE
Add identifier wrappers for review domain IDs

### DIFF
--- a/crates/card-store/tests/identifier_wrappers.rs
+++ b/crates/card-store/tests/identifier_wrappers.rs
@@ -1,0 +1,46 @@
+use std::fmt::Write;
+
+use review_domain::ids::{CardId, EdgeId, IdConversionError, IdKind, MoveId, PositionId};
+
+#[test]
+fn id_conversion_errors_surface_kind_labels() {
+    let overflow = CardId::try_from(u128::from(u64::MAX) + 1).expect_err("overflow should error");
+    let negative = EdgeId::try_from(-1_i64).expect_err("negative should error");
+
+    match overflow {
+        IdConversionError::Overflow { kind, value, max } => {
+            assert_eq!(kind, IdKind::Card);
+            assert_eq!(value, u128::from(u64::MAX) + 1);
+            assert_eq!(max, u64::MAX);
+            assert_eq!(kind.to_string(), "card");
+        }
+        IdConversionError::Negative { .. } => panic!("expected overflow"),
+    }
+
+    match negative {
+        IdConversionError::Negative { kind, value } => {
+            assert_eq!(kind, IdKind::Edge);
+            assert_eq!(value, -1);
+            assert_eq!(kind.to_string(), "edge");
+        }
+        IdConversionError::Overflow { .. } => panic!("expected negative"),
+    }
+}
+
+#[test]
+fn ids_integrate_with_card_store_helpers() {
+    let mut buffer = String::new();
+
+    let position = PositionId::from(42_u64);
+    let edge = EdgeId::from(72_u64);
+    let mov = MoveId::from(99_u64);
+    let card = CardId::from(7_u64);
+
+    write!(&mut buffer, "{position}:{edge}:{mov}:{card}").unwrap();
+
+    assert_eq!(buffer, "42:72:99:7");
+    assert_eq!(u64::from(position), 42);
+    assert_eq!(u64::from(edge), 72);
+    assert_eq!(u64::from(mov), 99);
+    assert_eq!(u64::from(card), 7);
+}

--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -88,8 +88,12 @@ mod tests {
         let clone = original.clone();
 
         assert_eq!(original, clone);
-        assert!(std::ptr::eq(&original, &original));
-        assert!(!std::ptr::eq(&original, &clone));
+
+        let original_ptr = core::ptr::addr_of!(original);
+        let clone_ptr = core::ptr::addr_of!(clone);
+
+        assert!(core::ptr::addr_eq(original_ptr, original_ptr));
+        assert!(!core::ptr::addr_eq(original_ptr, clone_ptr));
     }
 
     #[test]
@@ -105,7 +109,7 @@ mod tests {
         card.state.interval_days += 5;
         card.state.lapses += 1;
 
-        assert_eq!(card.state.ease, 2.8);
+        assert!((card.state.ease - 2.8).abs() < f32::EPSILON);
         assert_eq!(card.state.interval_days, 15);
         assert_eq!(card.state.lapses, 1);
     }

--- a/crates/review-domain/src/ids.rs
+++ b/crates/review-domain/src/ids.rs
@@ -1,0 +1,128 @@
+//! Identifier wrappers for review-domain entities.
+
+use core::fmt;
+use thiserror::Error;
+
+/// Enumerates the identifier categories supported by this crate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IdKind {
+    /// Identifier representing a chess position.
+    Position,
+    /// Identifier representing a repertoire edge.
+    Edge,
+    /// Identifier representing a move hashed from SAN/position context.
+    Move,
+    /// Identifier representing a review card instance.
+    Card,
+}
+
+impl fmt::Display for IdKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::Position => "position",
+            Self::Edge => "edge",
+            Self::Move => "move",
+            Self::Card => "card",
+        };
+
+        f.write_str(label)
+    }
+}
+
+/// Errors that occur when attempting to convert primitive values into identifier wrappers.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum IdConversionError {
+    /// Returned when a signed integer is negative.
+    #[error("{kind} identifiers cannot be negative (received {value})")]
+    Negative {
+        /// The category of identifier being constructed.
+        kind: IdKind,
+        /// The offending value.
+        value: i128,
+    },
+    /// Returned when an unsigned integer exceeds [`u64::MAX`].
+    #[error("{kind} identifiers must be at most {max} (received {value})")]
+    Overflow {
+        /// The category of identifier being constructed.
+        kind: IdKind,
+        /// The offending value.
+        value: u128,
+        /// Maximum supported value.
+        max: u64,
+    },
+}
+
+macro_rules! define_id {
+    ($name:ident, $kind:expr) => {
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[repr(transparent)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        pub struct $name(u64);
+
+        impl $name {
+            /// Creates a new identifier from a raw [`u64`] value.
+            #[must_use]
+            pub const fn new(value: u64) -> Self {
+                Self(value)
+            }
+
+            /// Returns the raw [`u64`] backing this identifier.
+            #[must_use]
+            pub const fn get(self) -> u64 {
+                self.0
+            }
+        }
+
+        impl From<u64> for $name {
+            fn from(value: u64) -> Self {
+                Self::new(value)
+            }
+        }
+
+        impl From<$name> for u64 {
+            fn from(value: $name) -> Self {
+                value.get()
+            }
+        }
+
+        impl TryFrom<i64> for $name {
+            type Error = IdConversionError;
+
+            fn try_from(value: i64) -> Result<Self, Self::Error> {
+                match u64::try_from(value) {
+                    Ok(raw) => Ok(Self::new(raw)),
+                    Err(_) => Err(IdConversionError::Negative {
+                        kind: $kind,
+                        value: i128::from(value),
+                    }),
+                }
+            }
+        }
+
+        impl TryFrom<u128> for $name {
+            type Error = IdConversionError;
+
+            fn try_from(value: u128) -> Result<Self, Self::Error> {
+                match u64::try_from(value) {
+                    Ok(raw) => Ok(Self::new(raw)),
+                    Err(_) => Err(IdConversionError::Overflow {
+                        kind: $kind,
+                        value,
+                        max: u64::MAX,
+                    }),
+                }
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.get())
+            }
+        }
+    };
+}
+
+define_id!(PositionId, IdKind::Position);
+define_id!(EdgeId, IdKind::Edge);
+define_id!(MoveId, IdKind::Move);
+define_id!(CardId, IdKind::Card);

--- a/crates/review-domain/src/lib.rs
+++ b/crates/review-domain/src/lib.rs
@@ -5,6 +5,7 @@ pub mod card_kind;
 pub mod card_state;
 pub mod grade;
 pub mod hash;
+pub mod ids;
 pub mod macros;
 pub mod opening;
 pub mod position;
@@ -25,6 +26,8 @@ pub use card_state::StoredCardState;
 pub use grade::{GradeError, ValidGrade};
 /// Deterministic hashing helper backed by BLAKE3.
 pub use hash::hash64;
+/// Identifier wrappers for repertoire entities and review cards.
+pub use ids::{CardId, EdgeId, IdConversionError, IdKind, MoveId, PositionId};
 /// Opening-focused request and payload types.
 pub use opening::{EdgeInput, OpeningCard, OpeningEdge};
 /// Normalized chess position representation and related errors.

--- a/crates/review-domain/tests/ids.rs
+++ b/crates/review-domain/tests/ids.rs
@@ -1,0 +1,62 @@
+use review_domain::ids::{CardId, EdgeId, IdConversionError, MoveId, PositionId};
+
+#[test]
+fn id_round_trips_through_u64_conversions() {
+    let position = PositionId::from(42_u64);
+    let edge = EdgeId::from(87_u64);
+    let mov = MoveId::from(99_u64);
+    let card = CardId::from(123_u64);
+
+    assert_eq!(u64::from(position), 42);
+    assert_eq!(u64::from(edge), 87);
+    assert_eq!(u64::from(mov), 99);
+    assert_eq!(u64::from(card), 123);
+}
+
+#[test]
+fn try_from_i64_rejects_negative_values() {
+    let negative = -27_i64;
+
+    assert!(matches!(
+        PositionId::try_from(negative),
+        Err(IdConversionError::Negative { .. })
+    ));
+    assert!(matches!(
+        EdgeId::try_from(negative),
+        Err(IdConversionError::Negative { .. })
+    ));
+    assert!(matches!(
+        MoveId::try_from(negative),
+        Err(IdConversionError::Negative { .. })
+    ));
+    assert!(matches!(
+        CardId::try_from(negative),
+        Err(IdConversionError::Negative { .. })
+    ));
+}
+
+#[test]
+fn ids_order_by_their_numeric_value() {
+    let low = CardId::from(1_u64);
+    let high = CardId::from(2_u64);
+
+    assert!(low < high);
+    assert!(high > low);
+}
+
+#[cfg(feature = "serde")]
+mod serde_support {
+    use super::*;
+
+    #[test]
+    fn ids_serialize_and_deserialize_as_numbers() {
+        let original = EdgeId::from(512_u64);
+        let serialized = serde_json::to_string(&original).expect("serialize id");
+
+        assert_eq!(serialized, "512");
+
+        let round_trip: EdgeId = serde_json::from_str(&serialized).expect("deserialize id");
+
+        assert_eq!(round_trip, original);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a new `ids` module in `review-domain` with typed wrappers, conversions, and serde support for card, position, edge, and move identifiers
- expose the wrappers through the crate root and update local unit tests to satisfy strict clippy pedantic requirements
- add integration tests in `review-domain` and `card-store` to cover the new identifier API across the workspace

## Testing
- `make test` *(fails: web-ui lint is currently broken in mainline and requires type refactors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0fecfc60832583c9a0f118193333