### PR TITLE
Add scheduler HTTP contract types to review domain

### DIFF
--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -88,8 +88,9 @@ mod tests {
         let clone = original.clone();
 
         assert_eq!(original, clone);
-        assert!(std::ptr::eq(&original, &original));
-        assert!(!std::ptr::eq(&original, &clone));
+        let original_ptr = std::ptr::from_ref(&original);
+        assert!(std::ptr::eq(original_ptr, std::ptr::from_ref(&original)));
+        assert!(!std::ptr::eq(original_ptr, std::ptr::from_ref(&clone)));
     }
 
     #[test]
@@ -101,11 +102,11 @@ mod tests {
             state: CardState::new(2.5, 10, 0),
         };
 
-        card.state.ease = 2.8;
+        card.state.ease = 2.8_f32;
         card.state.interval_days += 5;
         card.state.lapses += 1;
 
-        assert_eq!(card.state.ease, 2.8);
+        assert!((card.state.ease - 2.8_f32).abs() < f32::EPSILON);
         assert_eq!(card.state.interval_days, 15);
         assert_eq!(card.state.lapses, 1);
     }

--- a/crates/review-domain/src/lib.rs
+++ b/crates/review-domain/src/lib.rs
@@ -11,6 +11,7 @@ pub mod position;
 pub mod repertoire;
 pub mod review;
 pub mod review_grade;
+pub mod scheduler_contract;
 pub mod study_stage;
 pub mod tactic;
 pub mod unlock;
@@ -35,6 +36,11 @@ pub use repertoire::{Repertoire, RepertoireError, RepertoireMove};
 pub use review::ReviewRequest;
 /// Grading scale for spaced repetition reviews.
 pub use review_grade::ReviewGrade;
+/// HTTP contract types for interacting with the scheduler service.
+pub use scheduler_contract::{
+    CardSummary, CardSummaryKind, CardSummaryMetaValue, GradeRequest, GradeResponse, QueueRequest,
+    QueueResponse, SessionStats,
+};
 /// Learning stage classification for cards.
 pub use study_stage::StudyStage;
 /// Tactic-focused card payloads.

--- a/crates/review-domain/src/review_grade.rs
+++ b/crates/review-domain/src/review_grade.rs
@@ -2,6 +2,8 @@
 
 /// Possible outcomes of a learner's review session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
 pub enum ReviewGrade {
     /// The user failed to recall the item; schedule for immediate relearning.
     Again,

--- a/crates/review-domain/src/scheduler_contract.rs
+++ b/crates/review-domain/src/scheduler_contract.rs
@@ -1,0 +1,323 @@
+//! Scheduler HTTP API contracts used by back-end services and gateways.
+
+use std::collections::BTreeMap;
+
+use crate::review_grade::ReviewGrade;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Request payload sent to the scheduler `/queue` endpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct QueueRequest {
+    /// Identifier of the learner whose queue is being fetched.
+    pub user_id: String,
+}
+
+impl QueueRequest {
+    /// Construct a new queue request for the provided learner identifier.
+    #[must_use]
+    pub fn new(user_id: impl Into<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+        }
+    }
+}
+
+/// Response body produced by the scheduler `/queue` endpoint.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct QueueResponse {
+    /// Ordered collection of cards that should be reviewed next.
+    pub queue: Vec<CardSummary>,
+}
+
+impl QueueResponse {
+    /// Create a queue response from the provided card summaries.
+    #[must_use]
+    pub fn new(queue: Vec<CardSummary>) -> Self {
+        Self { queue }
+    }
+}
+
+/// Minimal card description shared across the scheduler contract.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct CardSummary {
+    /// Identifier used to refer to the card in follow-up requests.
+    pub card_id: String,
+    /// High-level card classification.
+    pub kind: CardSummaryKind,
+    /// Chess position presented to the learner.
+    pub position_fen: String,
+    /// Prompt displayed to the learner when the card becomes active.
+    pub prompt: String,
+    /// Expected best-move sequence in UCI notation.
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
+    pub expected_moves_uci: Option<Vec<String>>,
+    /// Principal variation in UCI notation used for teaching overlays.
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
+    pub pv_uci: Option<Vec<String>>,
+    /// Optional metadata consumed by downstream clients.
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
+    pub meta: Option<BTreeMap<String, CardSummaryMetaValue>>,
+}
+
+impl CardSummary {
+    /// Create a new card summary with the required fields populated.
+    #[must_use]
+    pub fn new(
+        card_id: impl Into<String>,
+        kind: CardSummaryKind,
+        position_fen: impl Into<String>,
+        prompt: impl Into<String>,
+    ) -> Self {
+        Self {
+            card_id: card_id.into(),
+            kind,
+            position_fen: position_fen.into(),
+            prompt: prompt.into(),
+            expected_moves_uci: None,
+            pv_uci: None,
+            meta: None,
+        }
+    }
+
+    /// Attach the expected move list in UCI notation.
+    #[must_use]
+    pub fn with_expected_moves<I, S>(mut self, moves: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.expected_moves_uci = Some(moves.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Attach the principal variation in UCI notation used for teaching overlays.
+    #[must_use]
+    pub fn with_pv<I, S>(mut self, moves: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.pv_uci = Some(moves.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Attach metadata describing supplemental teaching content.
+    #[must_use]
+    pub fn with_meta(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<CardSummaryMetaValue>,
+    ) -> Self {
+        let entry = value.into();
+        if let Some(meta) = &mut self.meta {
+            meta.insert(key.into(), entry);
+        } else {
+            let mut meta = BTreeMap::new();
+            meta.insert(key.into(), entry);
+            self.meta = Some(meta);
+        }
+        self
+    }
+}
+
+/// Classification for card summaries used in the scheduler contract.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
+pub enum CardSummaryKind {
+    /// Card originating from an opening repertoire.
+    Opening,
+    /// Card representing a tactic pattern.
+    Tactic,
+}
+
+/// Values permitted inside the metadata bag of a card summary.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+pub enum CardSummaryMetaValue {
+    /// Textual metadata value.
+    Text(String),
+    /// Numeric metadata value.
+    Number(f64),
+}
+
+impl From<String> for CardSummaryMetaValue {
+    fn from(value: String) -> Self {
+        CardSummaryMetaValue::Text(value)
+    }
+}
+
+impl From<&str> for CardSummaryMetaValue {
+    fn from(value: &str) -> Self {
+        CardSummaryMetaValue::Text(value.to_owned())
+    }
+}
+
+impl From<f64> for CardSummaryMetaValue {
+    fn from(value: f64) -> Self {
+        CardSummaryMetaValue::Number(value)
+    }
+}
+
+impl From<f32> for CardSummaryMetaValue {
+    fn from(value: f32) -> Self {
+        CardSummaryMetaValue::Number(f64::from(value))
+    }
+}
+
+impl From<u32> for CardSummaryMetaValue {
+    fn from(value: u32) -> Self {
+        CardSummaryMetaValue::Number(f64::from(value))
+    }
+}
+
+impl From<u64> for CardSummaryMetaValue {
+    #[allow(clippy::cast_precision_loss)]
+    fn from(value: u64) -> Self {
+        CardSummaryMetaValue::Number(value as f64)
+    }
+}
+
+impl From<i32> for CardSummaryMetaValue {
+    fn from(value: i32) -> Self {
+        CardSummaryMetaValue::Number(f64::from(value))
+    }
+}
+
+impl From<i64> for CardSummaryMetaValue {
+    #[allow(clippy::cast_precision_loss)]
+    fn from(value: i64) -> Self {
+        CardSummaryMetaValue::Number(value as f64)
+    }
+}
+
+/// Grade submission payload accepted by the scheduler `/grade` endpoint.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct GradeRequest {
+    /// Identifier of the client-maintained study session.
+    pub session_id: String,
+    /// Identifier of the graded card.
+    pub card_id: String,
+    /// Grade awarded to the card.
+    pub grade: ReviewGrade,
+    /// Latency in milliseconds between presenting the card and receiving the grade.
+    pub latency_ms: u32,
+}
+
+impl GradeRequest {
+    /// Construct a new grade request for the provided session and card identifiers.
+    #[must_use]
+    pub fn new(
+        session_id: impl Into<String>,
+        card_id: impl Into<String>,
+        grade: ReviewGrade,
+        latency_ms: u32,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            card_id: card_id.into(),
+            grade,
+            latency_ms,
+        }
+    }
+}
+
+/// Response body emitted by the scheduler `/grade` endpoint.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct GradeResponse {
+    /// Next card to study, if any remain in the queue.
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", default)
+    )]
+    pub next_card: Option<CardSummary>,
+    /// Updated session statistics for the learner.
+    pub stats: SessionStats,
+}
+
+impl GradeResponse {
+    /// Construct a new grade response with the provided next card and session statistics.
+    #[must_use]
+    pub fn new(next_card: Option<CardSummary>, stats: SessionStats) -> Self {
+        Self { next_card, stats }
+    }
+}
+
+/// Aggregated statistics returned to clients alongside queue and grade responses.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SessionStats {
+    /// Total number of reviews completed today.
+    pub reviews_today: u32,
+    /// Rolling accuracy for the current session.
+    pub accuracy: f64,
+    /// Average response latency in milliseconds.
+    pub avg_latency_ms: u32,
+    /// Number of cards still due for review.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub due_count: u32,
+    /// Number of cards completed in the session.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub completed_count: u32,
+}
+
+impl SessionStats {
+    /// Create session statistics with zeroed due/completed counts.
+    #[must_use]
+    pub fn new(reviews_today: u32, accuracy: f64, avg_latency_ms: u32) -> Self {
+        Self {
+            reviews_today,
+            accuracy,
+            avg_latency_ms,
+            due_count: 0,
+            completed_count: 0,
+        }
+    }
+
+    /// Update the number of cards still due for review.
+    #[must_use]
+    pub fn with_due_count(mut self, due_count: u32) -> Self {
+        self.due_count = due_count;
+        self
+    }
+
+    /// Update the number of cards completed in the session.
+    #[must_use]
+    pub fn with_completed_count(mut self, completed_count: u32) -> Self {
+        self.completed_count = completed_count;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_meta_initializes_map() {
+        let summary = CardSummary::new("card", CardSummaryKind::Opening, "fen", "prompt")
+            .with_meta("note", "Remember the plan");
+        let meta = summary.meta.expect("meta should be populated");
+        assert_eq!(
+            meta.get("note"),
+            Some(&CardSummaryMetaValue::Text("Remember the plan".into()))
+        );
+    }
+}

--- a/crates/review-domain/tests/scheduler_contract.rs
+++ b/crates/review-domain/tests/scheduler_contract.rs
@@ -1,0 +1,129 @@
+use review_domain::ReviewGrade;
+use review_domain::scheduler_contract::{
+    CardSummary, CardSummaryKind, CardSummaryMetaValue, GradeRequest, QueueRequest,
+};
+
+#[cfg(feature = "serde")]
+use review_domain::scheduler_contract::{GradeResponse, QueueResponse, SessionStats};
+
+#[test]
+fn queue_request_exposes_user_id() {
+    let request = QueueRequest::new("user-123");
+    assert_eq!(request.user_id, "user-123");
+}
+
+#[test]
+fn card_summary_helpers_populate_optional_fields() {
+    let summary = CardSummary::new(
+        "card-1",
+        CardSummaryKind::Opening,
+        "startpos",
+        "Play the main line",
+    )
+    .with_expected_moves(["e2e4", "e7e5"])
+    .with_pv(["e2e4", "e7e5", "g1f3"])
+    .with_meta("teaching_note", "Focus on central control")
+    .with_meta("difficulty", 0.5);
+
+    assert_eq!(
+        summary.expected_moves_uci,
+        Some(vec!["e2e4".to_string(), "e7e5".to_string()])
+    );
+    assert_eq!(
+        summary.pv_uci,
+        Some(vec![
+            "e2e4".to_string(),
+            "e7e5".to_string(),
+            "g1f3".to_string()
+        ])
+    );
+    let meta = summary.meta.expect("meta should be present");
+    assert_eq!(
+        meta.get("teaching_note"),
+        Some(&CardSummaryMetaValue::Text(
+            "Focus on central control".to_string()
+        ))
+    );
+    assert_eq!(
+        meta.get("difficulty"),
+        Some(&CardSummaryMetaValue::Number(0.5))
+    );
+}
+
+#[test]
+fn grade_request_captures_latency_and_grade() {
+    let request = GradeRequest::new("session-1", "card-42", ReviewGrade::Good, 1_200);
+    assert_eq!(request.session_id, "session-1");
+    assert_eq!(request.card_id, "card-42");
+    assert_eq!(request.grade, ReviewGrade::Good);
+    assert_eq!(request.latency_ms, 1_200);
+}
+
+#[cfg(feature = "serde")]
+use serde_json::json;
+
+#[cfg(feature = "serde")]
+#[test]
+fn queue_response_serializes_expected_shape() {
+    let summary = CardSummary::new(
+        "card-99",
+        CardSummaryKind::Tactic,
+        "8/8/8/8/8/8/8/8 w - - 0 1",
+        "Find the winning tactic",
+    )
+    .with_meta("theme", "Fork")
+    .with_expected_moves(["e5f7"]);
+    let response = QueueResponse::new(vec![summary]);
+
+    let json = serde_json::to_value(response).expect("serialization should succeed");
+    let expected = json!({
+        "queue": [
+            {
+                "card_id": "card-99",
+                "kind": "Tactic",
+                "position_fen": "8/8/8/8/8/8/8/8 w - - 0 1",
+                "prompt": "Find the winning tactic",
+                "expected_moves_uci": ["e5f7"],
+                "meta": { "theme": "Fork" }
+            }
+        ]
+    });
+
+    assert_eq!(json, expected);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn grade_response_serializes_stats_and_next_card() {
+    let stats = SessionStats::new(3, 0.75, 1_100)
+        .with_due_count(25)
+        .with_completed_count(12);
+    let next_card = CardSummary::new(
+        "card-100",
+        CardSummaryKind::Opening,
+        "startpos",
+        "Remember the theory",
+    )
+    .with_meta("line", "Ruy Lopez");
+    let response = GradeResponse::new(Some(next_card), stats);
+
+    let json = serde_json::to_value(response).expect("serialization should succeed");
+    let expected = json!({
+        "next_card": {
+            "card_id": "card-100",
+            "kind": "Opening",
+            "position_fen": "startpos",
+            "prompt": "Remember the theory",
+            "meta": { "line": "Ruy Lopez" }
+        },
+        "stats": {
+            "reviews_today": 3,
+            "accuracy": 0.75,
+            "avg_latency_ms": 1_100,
+            "due_count": 25,
+            "completed_count": 12
+        }
+    });
+
+    assert_eq!(json, expected);
+}


### PR DESCRIPTION
## Summary
- add a scheduler_contract module with request/response payloads, card summaries, metadata helpers, and session stats for the HTTP scheduler API
- expose the new scheduler contracts and serde-enabled ReviewGrade from the review-domain crate
- extend review-domain integration tests to cover the scheduler contract helpers and serialization flow

## Testing
- cargo test -p review-domain

------
https://chatgpt.com/codex/tasks/task_e_68ec13c318ec83259c2382b4f7983cb6