### PR TITLE
Add OpeningGraph navigation API

### DIFF
--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -15,6 +15,8 @@ pub struct Card<Id, Owner, Kind, State> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::borrow_as_ptr, clippy::float_cmp)]
+
     use super::Card;
 
     #[derive(Clone, Debug, PartialEq)]

--- a/crates/review-domain/src/lib.rs
+++ b/crates/review-domain/src/lib.rs
@@ -29,8 +29,8 @@ pub use hash::hash64;
 pub use opening::{EdgeInput, OpeningCard, OpeningEdge};
 /// Normalized chess position representation and related errors.
 pub use position::{ChessPosition, PositionError};
-/// Opening repertoire store and associated move representation.
-pub use repertoire::{Repertoire, RepertoireError, RepertoireMove};
+/// Opening repertoire store, adjacency graph, and associated move representation.
+pub use repertoire::{OpeningGraph, Repertoire, RepertoireError, RepertoireMove};
 /// Review submission payload capturing user input.
 pub use review::ReviewRequest;
 /// Grading scale for spaced repetition reviews.

--- a/crates/review-domain/src/repertoire/mod.rs
+++ b/crates/review-domain/src/repertoire/mod.rs
@@ -1,10 +1,12 @@
 //! Canonical representation of stored opening repertoire moves.
 
 pub mod move_;
+pub mod opening_graph;
 pub mod repertoire_;
 pub mod repertoire_error;
 
 pub use move_::RepertoireMove;
+pub use opening_graph::OpeningGraph;
 pub use repertoire_::Repertoire;
 pub use repertoire_error::RepertoireError;
 

--- a/crates/review-domain/src/repertoire/opening_graph.rs
+++ b/crates/review-domain/src/repertoire/opening_graph.rs
@@ -1,0 +1,121 @@
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+
+use crate::RepertoireMove;
+
+#[derive(Clone, Debug, Default)]
+pub struct OpeningGraph {
+    edges: Vec<RepertoireMove>,
+    by_parent: HashMap<u64, Vec<usize>>,
+    by_child: HashMap<u64, Vec<usize>>,
+    roots: Vec<u64>,
+    positions: HashSet<u64>,
+}
+
+impl OpeningGraph {
+    #[must_use]
+    pub fn from_moves<I>(moves: I) -> Self
+    where
+        I: IntoIterator<Item = RepertoireMove>,
+    {
+        let mut edges = Vec::new();
+        let mut by_parent: HashMap<u64, Vec<usize>> = HashMap::new();
+        let mut by_child: HashMap<u64, Vec<usize>> = HashMap::new();
+        let mut positions: HashSet<u64> = HashSet::new();
+
+        for move_entry in moves {
+            positions.insert(move_entry.parent_id);
+            positions.insert(move_entry.child_id);
+
+            let edge_index = edges.len();
+            by_parent
+                .entry(move_entry.parent_id)
+                .or_default()
+                .push(edge_index);
+            by_child
+                .entry(move_entry.child_id)
+                .or_default()
+                .push(edge_index);
+
+            edges.push(move_entry);
+        }
+
+        let mut roots = BTreeSet::new();
+        for position in &positions {
+            if !by_child.contains_key(position) {
+                roots.insert(*position);
+            }
+        }
+
+        Self {
+            edges,
+            by_parent,
+            by_child,
+            roots: roots.into_iter().collect(),
+            positions,
+        }
+    }
+
+    pub fn children(&self, position_id: u64) -> impl Iterator<Item = &RepertoireMove> {
+        self.by_parent
+            .get(&position_id)
+            .into_iter()
+            .flatten()
+            .map(|&idx| &self.edges[idx])
+    }
+
+    pub fn parents(&self, position_id: u64) -> impl Iterator<Item = &RepertoireMove> {
+        self.by_child
+            .get(&position_id)
+            .into_iter()
+            .flatten()
+            .map(|&idx| &self.edges[idx])
+    }
+
+    #[must_use]
+    pub fn path_to(&self, position_id: u64) -> Option<Vec<&RepertoireMove>> {
+        if !self.positions.contains(&position_id) {
+            return None;
+        }
+
+        if self.roots.contains(&position_id) {
+            return Some(Vec::new());
+        }
+
+        let mut visited = HashSet::new();
+        let mut queue: VecDeque<(u64, Vec<usize>)> = VecDeque::new();
+
+        for &root in &self.roots {
+            queue.push_back((root, Vec::new()));
+        }
+
+        while let Some((current, path_indices)) = queue.pop_front() {
+            if current == position_id {
+                let path = path_indices
+                    .into_iter()
+                    .map(|idx| &self.edges[idx])
+                    .collect();
+                return Some(path);
+            }
+
+            if !visited.insert(current) {
+                continue;
+            }
+
+            if let Some(children) = self.by_parent.get(&current) {
+                for &edge_idx in children {
+                    let mut next_path = path_indices.clone();
+                    next_path.push(edge_idx);
+                    let child = self.edges[edge_idx].child_id;
+                    queue.push_back((child, next_path));
+                }
+            }
+        }
+
+        None
+    }
+
+    #[must_use]
+    pub fn roots(&self) -> &[u64] {
+        &self.roots
+    }
+}

--- a/crates/review-domain/tests/opening_graph.rs
+++ b/crates/review-domain/tests/opening_graph.rs
@@ -1,0 +1,63 @@
+use review_domain::{OpeningGraph, RepertoireMove};
+
+fn sample_graph() -> OpeningGraph {
+    let moves = vec![
+        RepertoireMove::new(1, 1, 2, "e2e4", "e4"),
+        RepertoireMove::new(2, 2, 3, "g1f3", "Nf3"),
+        RepertoireMove::new(3, 1, 4, "d2d4", "d4"),
+        RepertoireMove::new(4, 4, 5, "c2c4", "c4"),
+        RepertoireMove::new(5, 3, 6, "f1c4", "Bc4"),
+        RepertoireMove::new(6, 10, 11, "a2a3", "a3"),
+    ];
+
+    OpeningGraph::from_moves(moves)
+}
+
+#[test]
+fn children_returns_outgoing_edges_for_position() {
+    let graph = sample_graph();
+
+    let child_edges: Vec<_> = graph.children(1).collect();
+    assert_eq!(child_edges.len(), 2);
+    assert_eq!(child_edges[0].edge_id, 1);
+    assert_eq!(child_edges[1].edge_id, 3);
+
+    let empty: Vec<_> = graph.children(42).collect();
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn parents_returns_incoming_edges_for_position() {
+    let graph = sample_graph();
+
+    let parent_edges: Vec<_> = graph.parents(3).collect();
+    assert_eq!(parent_edges.len(), 1);
+    assert_eq!(parent_edges[0].edge_id, 2);
+
+    let root_parents: Vec<_> = graph.parents(1).collect();
+    assert!(root_parents.is_empty());
+}
+
+#[test]
+fn roots_reports_positions_without_parents() {
+    let graph = sample_graph();
+    assert_eq!(graph.roots(), &[1, 10]);
+}
+
+#[test]
+fn path_to_returns_sequence_from_root() {
+    let graph = sample_graph();
+
+    let path_to_six: Vec<_> = graph
+        .path_to(6)
+        .expect("position reachable")
+        .into_iter()
+        .map(|edge| edge.edge_id)
+        .collect();
+    assert_eq!(path_to_six, vec![1, 2, 5]);
+
+    let root_path = graph.path_to(1).expect("root present");
+    assert!(root_path.is_empty());
+
+    assert!(graph.path_to(99).is_none());
+}


### PR DESCRIPTION
## Summary
- implement the OpeningGraph adjacency structure along with child, parent, root, and path traversal helpers
- expose the graph type through the repertoire module and cover the behaviour with new integration tests
- silence clippy pedantic warnings inside the legacy card tests module

## Testing
- `cargo test -p review-domain --test opening_graph`
- `make test` *(fails: npm lint exits because existing web-ui interfaces violate the TypeScript lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ec10e9018c83258d670542d9369a4f