### PR TITLE
feat(review-domain): introduce opening graph scaffolding

### DIFF
--- a/crates/card-store/tests/opening_graph_bridge.rs
+++ b/crates/card-store/tests/opening_graph_bridge.rs
@@ -1,0 +1,91 @@
+use review_domain::opening::graph::{OpeningGraph, OpeningGraphError};
+use review_domain::repertoire::RepertoireMove;
+
+fn sample_moves() -> Vec<RepertoireMove> {
+    vec![
+        RepertoireMove::new(11, 1, 2, "e2e4", "e4"),
+        RepertoireMove::new(22, 2, 3, "e7e5", "...e5"),
+        RepertoireMove::new(33, 1, 4, "g1f3", "Nf3"),
+    ]
+}
+
+#[test]
+fn opening_graph_builds_and_exposes_adjacency() {
+    let graph = OpeningGraph::builder()
+        .ingest_moves(sample_moves())
+        .expect("valid move set ingests")
+        .build();
+
+    let mut positions: Vec<_> = graph.position_ids().collect();
+    positions.sort_unstable();
+    assert_eq!(positions, vec![1, 2, 3, 4]);
+
+    let node = graph.node(1).expect("root position exists");
+    assert_eq!(node.position_id(), 1);
+    assert_eq!(node.children().len(), 2);
+
+    let parents_of_three: Vec<_> = graph.parents(3).unwrap().iter().copied().collect();
+    assert_eq!(parents_of_three, vec![2]);
+
+    let children_of_one = graph.children(1).unwrap();
+    assert!(children_of_one.iter().any(|edge| edge.child_id == 2));
+    assert!(children_of_one.iter().any(|edge| edge.child_id == 4));
+
+    let rebuilt = OpeningGraph::try_from_moves(vec![
+        RepertoireMove::new(44, 5, 6, "d2d4", "d4"),
+        RepertoireMove::new(55, 6, 7, "d7d5", "...d5"),
+    ])
+    .expect("try_from_moves succeeds");
+
+    assert_eq!(
+        rebuilt
+            .parents(7)
+            .unwrap()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![6]
+    );
+    assert_eq!(rebuilt.children(5).unwrap().len(), 1);
+}
+
+#[test]
+fn opening_graph_detects_invariant_violations() {
+    let duplicate_edge_err = OpeningGraph::builder()
+        .ingest_moves(vec![
+            RepertoireMove::new(99, 1, 2, "e2e4", "e4"),
+            RepertoireMove::new(99, 1, 3, "d2d4", "d4"),
+        ])
+        .err()
+        .expect("duplicate edge ids rejected");
+    assert!(matches!(
+        duplicate_edge_err,
+        OpeningGraphError::DuplicateEdgeId { edge_id } if edge_id == 99
+    ));
+
+    let duplicate_child_err = OpeningGraph::builder()
+        .ingest_move(RepertoireMove::new(10, 1, 2, "e2e4", "e4"))
+        .expect("first move accepted")
+        .ingest_move(RepertoireMove::new(20, 1, 2, "e2e4", "e4"))
+        .err()
+        .expect("duplicate child rejected");
+    assert!(matches!(
+        duplicate_child_err,
+        OpeningGraphError::DuplicateChildEdge {
+            parent_id,
+            child_id,
+            existing_edge_id,
+            duplicate_edge_id,
+        } if parent_id == 1 && child_id == 2 && existing_edge_id == 10 && duplicate_edge_id == 20
+    ));
+
+    let self_loop_err = OpeningGraph::builder()
+        .ingest_moves(vec![RepertoireMove::new(7, 4, 4, "e2e4", "e4")])
+        .err()
+        .expect("self loop rejected");
+    assert!(matches!(
+        self_loop_err,
+        OpeningGraphError::SelfLoop { edge_id, position_id }
+            if edge_id == 7 && position_id == 4
+    ));
+}

--- a/crates/chess-training-pgn-import/tests/opening_graph_bridge.rs
+++ b/crates/chess-training-pgn-import/tests/opening_graph_bridge.rs
@@ -1,0 +1,47 @@
+use review_domain::opening::graph::{OpeningGraph, OpeningGraphError};
+use review_domain::repertoire::RepertoireMove;
+
+#[test]
+fn opening_graph_smoke_from_importer_dependency() {
+    let graph = OpeningGraph::builder()
+        .ingest_moves(vec![
+            RepertoireMove::new(1, 10, 11, "e2e4", "e4"),
+            RepertoireMove::new(2, 11, 12, "e7e5", "...e5"),
+            RepertoireMove::new(3, 10, 13, "g1f3", "Nf3"),
+        ])
+        .expect("builder accepts unique edges")
+        .build();
+
+    assert_eq!(
+        graph
+            .parents(11)
+            .unwrap()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![10]
+    );
+    assert_eq!(graph.children(10).unwrap().len(), 2);
+
+    let duplicate_error = OpeningGraph::builder()
+        .ingest_moves(vec![
+            RepertoireMove::new(9, 1, 2, "e2e4", "e4"),
+            RepertoireMove::new(9, 1, 3, "d2d4", "d4"),
+        ])
+        .err()
+        .expect("duplicate edge ids produce error");
+    assert!(matches!(
+        duplicate_error,
+        OpeningGraphError::DuplicateEdgeId { edge_id } if edge_id == 9
+    ));
+
+    let self_loop_error = OpeningGraph::builder()
+        .ingest_moves(vec![RepertoireMove::new(7, 4, 4, "e2e4", "e4")])
+        .err()
+        .expect("self loop disallowed");
+    assert!(matches!(
+        self_loop_error,
+        OpeningGraphError::SelfLoop { edge_id, position_id }
+            if edge_id == 7 && position_id == 4
+    ));
+}

--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -88,8 +88,10 @@ mod tests {
         let clone = original.clone();
 
         assert_eq!(original, clone);
-        assert!(std::ptr::eq(&original, &original));
-        assert!(!std::ptr::eq(&original, &clone));
+        let original_ptr = std::ptr::from_ref(&original);
+        let clone_ptr = std::ptr::from_ref(&clone);
+        assert!(std::ptr::eq(original_ptr, original_ptr));
+        assert!(!std::ptr::eq(original_ptr, clone_ptr));
     }
 
     #[test]
@@ -101,11 +103,11 @@ mod tests {
             state: CardState::new(2.5, 10, 0),
         };
 
-        card.state.ease = 2.8;
+        card.state.ease = 2.8_f32;
         card.state.interval_days += 5;
         card.state.lapses += 1;
 
-        assert_eq!(card.state.ease, 2.8);
+        assert!((card.state.ease - 2.8_f32).abs() < f32::EPSILON);
         assert_eq!(card.state.interval_days, 15);
         assert_eq!(card.state.lapses, 1);
     }

--- a/crates/review-domain/src/opening/graph.rs
+++ b/crates/review-domain/src/opening/graph.rs
@@ -1,0 +1,289 @@
+//! Opening repertoire adjacency graph structures.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use crate::repertoire::RepertoireMove;
+
+use super::OpeningEdge;
+
+/// Errors that can occur while constructing an [`OpeningGraph`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum OpeningGraphError {
+    /// Duplicate edge identifiers are not permitted because they make hashes ambiguous.
+    #[error("duplicate edge identifier {edge_id}")]
+    DuplicateEdgeId { edge_id: u64 },
+    /// A parent cannot have multiple edges leading to the same child position.
+    #[error(
+        "duplicate child {child_id} for parent {parent_id} (existing edge {existing_edge_id}, duplicate {duplicate_edge_id})"
+    )]
+    DuplicateChildEdge {
+        parent_id: u64,
+        child_id: u64,
+        existing_edge_id: u64,
+        duplicate_edge_id: u64,
+    },
+    /// Self loops violate DAG invariants required by repertoire traversal logic.
+    #[error("self loop detected for position {position_id} on edge {edge_id}")]
+    SelfLoop { edge_id: u64, position_id: u64 },
+}
+
+/// Node within an [`OpeningGraph`], tracking adjacency information.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PositionNode {
+    position_id: u64,
+    children: Vec<OpeningEdge>,
+    parents: BTreeSet<u64>,
+}
+
+impl PositionNode {
+    fn new(position_id: u64) -> Self {
+        Self {
+            position_id,
+            children: Vec::new(),
+            parents: BTreeSet::new(),
+        }
+    }
+
+    fn insert_child(&mut self, edge: OpeningEdge) -> Result<(), OpeningGraphError> {
+        if let Some(existing) = self
+            .children
+            .iter()
+            .find(|existing| existing.child_id == edge.child_id)
+        {
+            return Err(OpeningGraphError::DuplicateChildEdge {
+                parent_id: self.position_id,
+                child_id: edge.child_id,
+                existing_edge_id: existing.id,
+                duplicate_edge_id: edge.id,
+            });
+        }
+        self.children.push(edge);
+        Ok(())
+    }
+
+    fn add_parent(&mut self, parent_id: u64) {
+        self.parents.insert(parent_id);
+    }
+
+    /// Outgoing edges from this position.
+    #[must_use]
+    pub fn children(&self) -> &[OpeningEdge] {
+        &self.children
+    }
+
+    /// Incoming parent position identifiers.
+    #[must_use]
+    pub fn parents(&self) -> &BTreeSet<u64> {
+        &self.parents
+    }
+
+    /// Identifier of the represented position.
+    #[must_use]
+    pub fn position_id(&self) -> u64 {
+        self.position_id
+    }
+}
+
+/// Adjacency representation of a repertoire's opening moves.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct OpeningGraph {
+    positions: HashMap<u64, PositionNode>,
+}
+
+impl OpeningGraph {
+    /// Creates a new builder for assembling an [`OpeningGraph`].
+    #[must_use]
+    pub fn builder() -> OpeningGraphBuilder {
+        OpeningGraphBuilder::new()
+    }
+
+    /// Convenience helper to build a graph directly from repertoire moves.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OpeningGraphError`] when the provided moves contain
+    /// duplicate identifiers, duplicate child edges, or self loops.
+    pub fn try_from_moves<I>(moves: I) -> Result<Self, OpeningGraphError>
+    where
+        I: IntoIterator<Item = RepertoireMove>,
+    {
+        Ok(OpeningGraphBuilder::new().ingest_moves(moves)?.build())
+    }
+
+    /// Retrieves the node for a given position, if present.
+    #[must_use]
+    pub fn node(&self, position_id: u64) -> Option<&PositionNode> {
+        self.positions.get(&position_id)
+    }
+
+    /// Outgoing edges from a position.
+    #[must_use]
+    pub fn children(&self, position_id: u64) -> Option<&[OpeningEdge]> {
+        self.positions.get(&position_id).map(PositionNode::children)
+    }
+
+    /// Parent positions that lead into the specified node.
+    #[must_use]
+    pub fn parents(&self, position_id: u64) -> Option<&BTreeSet<u64>> {
+        self.positions.get(&position_id).map(PositionNode::parents)
+    }
+
+    /// Iterator over all stored position identifiers.
+    pub fn position_ids(&self) -> impl Iterator<Item = u64> + '_ {
+        self.positions.keys().copied()
+    }
+}
+
+/// Builder for [`OpeningGraph`], enforcing invariants during construction.
+#[derive(Default)]
+pub struct OpeningGraphBuilder {
+    positions: HashMap<u64, PositionNode>,
+    seen_edges: HashSet<u64>,
+}
+
+impl OpeningGraphBuilder {
+    /// Creates an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            positions: HashMap::new(),
+            seen_edges: HashSet::new(),
+        }
+    }
+
+    /// Ingests a single repertoire move, returning an updated builder on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OpeningGraphError`] when the move would violate graph
+    /// invariants (duplicate edge IDs, duplicate child edges, or self loops).
+    pub fn ingest_move(mut self, move_entry: RepertoireMove) -> Result<Self, OpeningGraphError> {
+        self.push_move(move_entry)?;
+        Ok(self)
+    }
+
+    /// Ingests a collection of repertoire moves.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OpeningGraphError`] when any move violates the graph
+    /// invariants enforced by [`OpeningGraphBuilder::ingest_move`].
+    pub fn ingest_moves<I>(mut self, moves: I) -> Result<Self, OpeningGraphError>
+    where
+        I: IntoIterator<Item = RepertoireMove>,
+    {
+        for move_entry in moves {
+            self.push_move(move_entry)?;
+        }
+        Ok(self)
+    }
+
+    /// Finalises the builder into an [`OpeningGraph`].
+    #[must_use]
+    pub fn build(self) -> OpeningGraph {
+        OpeningGraph {
+            positions: self.positions,
+        }
+    }
+
+    fn push_move(&mut self, move_entry: RepertoireMove) -> Result<(), OpeningGraphError> {
+        let RepertoireMove {
+            parent_id,
+            child_id,
+            edge_id,
+            move_uci,
+            move_san,
+        } = move_entry;
+
+        if parent_id == child_id {
+            return Err(OpeningGraphError::SelfLoop {
+                edge_id,
+                position_id: parent_id,
+            });
+        }
+
+        if !self.seen_edges.insert(edge_id) {
+            return Err(OpeningGraphError::DuplicateEdgeId { edge_id });
+        }
+
+        let edge = OpeningEdge::new(edge_id, parent_id, child_id, move_uci, move_san);
+
+        {
+            let parent_node = self
+                .positions
+                .entry(parent_id)
+                .or_insert_with(|| PositionNode::new(parent_id));
+            parent_node.insert_child(edge)?;
+        }
+
+        let child_node = self
+            .positions
+            .entry(child_id)
+            .or_insert_with(|| PositionNode::new(child_id));
+        child_node.add_parent(parent_id);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn move_entry(edge: u64, parent: u64, child: u64) -> RepertoireMove {
+        RepertoireMove::new(edge, parent, child, "e2e4", "e4")
+    }
+
+    #[test]
+    fn builder_detects_duplicate_edges() {
+        let mut builder = OpeningGraphBuilder::new();
+        assert!(builder.push_move(move_entry(1, 10, 11)).is_ok());
+        let err = builder.push_move(move_entry(1, 10, 12)).unwrap_err();
+        assert_eq!(err, OpeningGraphError::DuplicateEdgeId { edge_id: 1 });
+    }
+
+    #[test]
+    fn builder_detects_duplicate_children() {
+        let mut builder = OpeningGraphBuilder::new();
+        assert!(builder.push_move(move_entry(1, 10, 11)).is_ok());
+        let err = builder.push_move(move_entry(2, 10, 11)).unwrap_err();
+        assert_eq!(
+            err,
+            OpeningGraphError::DuplicateChildEdge {
+                parent_id: 10,
+                child_id: 11,
+                existing_edge_id: 1,
+                duplicate_edge_id: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn builder_detects_self_loops() {
+        let mut builder = OpeningGraphBuilder::new();
+        let err = builder.push_move(move_entry(3, 10, 10)).unwrap_err();
+        assert_eq!(
+            err,
+            OpeningGraphError::SelfLoop {
+                edge_id: 3,
+                position_id: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn graph_exposes_adjacency_helpers() {
+        let graph = OpeningGraph::try_from_moves(vec![
+            move_entry(1, 1, 2),
+            move_entry(2, 1, 3),
+            move_entry(3, 2, 4),
+        ])
+        .expect("graph builds");
+
+        let children = graph.children(1).unwrap();
+        assert_eq!(children.len(), 2);
+        assert!(children.iter().any(|edge| edge.child_id == 2));
+        let parents = graph.parents(4).unwrap();
+        assert_eq!(parents.iter().copied().collect::<Vec<_>>(), vec![2]);
+    }
+}

--- a/crates/review-domain/src/opening/mod.rs
+++ b/crates/review-domain/src/opening/mod.rs
@@ -3,6 +3,7 @@
 mod card;
 mod edge;
 mod edge_input;
+pub mod graph;
 
 pub use card::OpeningCard;
 pub use edge::OpeningEdge;

--- a/crates/review-domain/tests/opening_graph.rs
+++ b/crates/review-domain/tests/opening_graph.rs
@@ -1,0 +1,90 @@
+use review_domain::opening::graph::{OpeningGraph, OpeningGraphError};
+use review_domain::repertoire::RepertoireMove;
+
+fn sample_moves() -> Vec<RepertoireMove> {
+    vec![
+        RepertoireMove::new(10, 1, 2, "e2e4", "e4"),
+        RepertoireMove::new(20, 1, 3, "d2d4", "d4"),
+        RepertoireMove::new(30, 2, 4, "g1f3", "Nf3"),
+    ]
+}
+
+#[test]
+fn builder_produces_adjacency_graph() {
+    let graph = OpeningGraph::builder()
+        .ingest_moves(sample_moves())
+        .expect("ingestion succeeds")
+        .build();
+
+    let root_children = graph.children(1).expect("root position present in graph");
+    assert_eq!(root_children.len(), 2);
+    assert!(root_children.iter().any(|edge| edge.child_id == 2));
+    assert!(root_children.iter().any(|edge| edge.child_id == 3));
+
+    let node_two_parents: Vec<_> = graph
+        .parents(2)
+        .expect("child node tracked")
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(node_two_parents, vec![1]);
+
+    let node_four_parents: Vec<_> = graph
+        .parents(4)
+        .expect("grandchild node tracked")
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(node_four_parents, vec![2]);
+}
+
+#[test]
+fn duplicate_edge_ids_are_rejected() {
+    let err = OpeningGraph::builder()
+        .ingest_moves(vec![
+            RepertoireMove::new(42, 1, 2, "e2e4", "e4"),
+            RepertoireMove::new(42, 1, 3, "d2d4", "d4"),
+        ])
+        .err()
+        .expect("duplicate edge identifiers should fail");
+
+    assert!(matches!(
+        err,
+        OpeningGraphError::DuplicateEdgeId { edge_id } if edge_id == 42
+    ));
+}
+
+#[test]
+fn duplicate_children_from_parent_are_rejected() {
+    let err = OpeningGraph::builder()
+        .ingest_moves(vec![
+            RepertoireMove::new(100, 5, 6, "e2e4", "e4"),
+            RepertoireMove::new(200, 5, 6, "e2e4", "e4"),
+        ])
+        .err()
+        .expect("duplicate child edges must be rejected");
+
+    assert!(matches!(
+        err,
+        OpeningGraphError::DuplicateChildEdge {
+            parent_id,
+            child_id,
+            existing_edge_id,
+            duplicate_edge_id,
+        } if parent_id == 5 && child_id == 6 && existing_edge_id == 100 && duplicate_edge_id == 200
+    ));
+}
+
+#[test]
+fn self_loops_are_rejected() {
+    let err = OpeningGraph::builder()
+        .ingest_moves(vec![RepertoireMove::new(7, 9, 9, "e2e4", "e4")])
+        .err()
+        .expect("self loops should not be allowed");
+
+    assert!(matches!(
+        err,
+        OpeningGraphError::SelfLoop { edge_id, position_id }
+            if edge_id == 7 && position_id == 9
+    ));
+}

--- a/crates/scheduler-core/tests/opening_graph_bridge.rs
+++ b/crates/scheduler-core/tests/opening_graph_bridge.rs
@@ -1,0 +1,35 @@
+use review_domain::opening::graph::{OpeningGraph, OpeningGraphError};
+use review_domain::repertoire::RepertoireMove;
+
+#[test]
+fn opening_graph_is_accessible_to_scheduler() {
+    let graph = OpeningGraph::builder()
+        .ingest_moves(vec![
+            RepertoireMove::new(5, 100, 101, "e2e4", "e4"),
+            RepertoireMove::new(6, 101, 102, "e7e5", "...e5"),
+        ])
+        .expect("scheduler dependencies should ingest moves")
+        .build();
+
+    assert_eq!(
+        graph
+            .parents(101)
+            .unwrap()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![100]
+    );
+    assert_eq!(graph.children(100).unwrap()[0].child_id, 101);
+
+    let duplicate = OpeningGraph::builder()
+        .ingest_move(RepertoireMove::new(8, 200, 201, "d2d4", "d4"))
+        .expect("first move accepted")
+        .ingest_move(RepertoireMove::new(8, 200, 202, "c2c4", "c4"))
+        .err()
+        .expect("duplicate edge detected");
+    assert!(matches!(
+        duplicate,
+        OpeningGraphError::DuplicateEdgeId { edge_id } if edge_id == 8
+    ));
+}


### PR DESCRIPTION
## Summary
- add an `opening::graph` module with `OpeningGraph`, adjacency nodes, and builder/error types to model repertoire DAGs
- cover the new graph API with unit tests and dependency bridge tests so downstream coverage stays above thresholds
- update existing card tests to comply with pedantic clippy pointer and float checks

## Testing
- make test *(fails: `npm run lint` complains about existing interface signatures in `web-ui` application controllers and services)*

------
https://chatgpt.com/codex/tasks/task_e_68ec10b6f38c83258a39a138744adc55