### PR TITLE
Add opening graph legacy serializer and snapshot test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -320,6 +320,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -566,6 +584,18 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -811,6 +841,7 @@ dependencies = [
  "apache-avro",
  "blake3",
  "chrono",
+ "insta",
  "serde",
  "serde_json",
  "thiserror",
@@ -832,7 +863,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -956,6 +987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,7 +1038,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1280,11 +1317,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1294,15 +1356,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1312,9 +1380,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1324,9 +1404,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1336,15 +1428,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/review-domain/Cargo.toml
+++ b/crates/review-domain/Cargo.toml
@@ -16,3 +16,4 @@ apache-avro = { version = "0.16", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1"
+insta = { version = "1", features = ["json"] }

--- a/crates/review-domain/src/card.rs
+++ b/crates/review-domain/src/card.rs
@@ -88,8 +88,10 @@ mod tests {
         let clone = original.clone();
 
         assert_eq!(original, clone);
-        assert!(std::ptr::eq(&original, &original));
-        assert!(!std::ptr::eq(&original, &clone));
+        let original_ptr = std::ptr::from_ref(&original);
+        let clone_ptr = std::ptr::from_ref(&clone);
+        assert!(std::ptr::eq(original_ptr, original_ptr));
+        assert!(!std::ptr::eq(original_ptr, clone_ptr));
     }
 
     #[test]
@@ -105,7 +107,7 @@ mod tests {
         card.state.interval_days += 5;
         card.state.lapses += 1;
 
-        assert_eq!(card.state.ease, 2.8);
+        assert!((card.state.ease - 2.8).abs() < f32::EPSILON);
         assert_eq!(card.state.interval_days, 15);
         assert_eq!(card.state.lapses, 1);
     }

--- a/crates/review-domain/src/lib.rs
+++ b/crates/review-domain/src/lib.rs
@@ -26,7 +26,7 @@ pub use grade::{GradeError, ValidGrade};
 /// Deterministic hashing helper backed by BLAKE3.
 pub use hash::hash64;
 /// Opening-focused request and payload types.
-pub use opening::{EdgeInput, OpeningCard, OpeningEdge};
+pub use opening::{EdgeInput, OpeningCard, OpeningEdge, OpeningGraph, PositionNode};
 /// Normalized chess position representation and related errors.
 pub use position::{ChessPosition, PositionError};
 /// Opening repertoire store and associated move representation.

--- a/crates/review-domain/src/opening/graph.rs
+++ b/crates/review-domain/src/opening/graph.rs
@@ -1,0 +1,95 @@
+//! Opening graph representation with helpers for legacy serialization.
+
+use std::collections::HashMap;
+
+use crate::{opening::OpeningEdge, repertoire::RepertoireMove};
+
+/// Node representing a position within an [`OpeningGraph`].
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct PositionNode {
+    /// Unique identifier for the position.
+    pub position_id: u64,
+    /// Outgoing edges leading to child positions.
+    pub edges: Vec<OpeningEdge>,
+}
+
+impl PositionNode {
+    /// Creates a new [`PositionNode`] with no outgoing edges.
+    #[must_use]
+    pub fn new(position_id: u64) -> Self {
+        Self {
+            position_id,
+            edges: Vec::new(),
+        }
+    }
+
+    /// Registers an outgoing [`OpeningEdge`] from this position.
+    pub fn add_edge(&mut self, edge: OpeningEdge) {
+        self.edges.push(edge);
+    }
+}
+
+/// Directed graph of opening positions and edges.
+#[derive(Clone, Debug, Default)]
+pub struct OpeningGraph {
+    positions: HashMap<u64, PositionNode>,
+    edge_sequence: Vec<OpeningEdge>,
+}
+
+impl OpeningGraph {
+    /// Builds an [`OpeningGraph`] from an iterator of edges.
+    #[must_use]
+    pub fn from_edges<I>(edges: I) -> Self
+    where
+        I: IntoIterator<Item = OpeningEdge>,
+    {
+        let mut positions = HashMap::new();
+        let mut edge_sequence = Vec::new();
+
+        for edge in edges {
+            positions
+                .entry(edge.parent_id)
+                .or_insert_with(|| PositionNode::new(edge.parent_id))
+                .add_edge(edge.clone());
+
+            positions
+                .entry(edge.child_id)
+                .or_insert_with(|| PositionNode::new(edge.child_id));
+
+            edge_sequence.push(edge);
+        }
+
+        Self {
+            positions,
+            edge_sequence,
+        }
+    }
+
+    /// Flattens the graph back into the legacy edge list ordering.
+    #[must_use]
+    pub fn legacy_moves(&self) -> Vec<RepertoireMove> {
+        self.edge_sequence
+            .iter()
+            .map(|edge| {
+                RepertoireMove::new(
+                    edge.id,
+                    edge.parent_id,
+                    edge.child_id,
+                    edge.move_uci.clone(),
+                    edge.move_san.clone(),
+                )
+            })
+            .collect()
+    }
+
+    /// Retrieves a position node by its identifier.
+    #[must_use]
+    pub fn position(&self, position_id: u64) -> Option<&PositionNode> {
+        self.positions.get(&position_id)
+    }
+
+    /// Returns an iterator over all tracked positions.
+    pub fn positions(&self) -> impl Iterator<Item = &PositionNode> {
+        self.positions.values()
+    }
+}

--- a/crates/review-domain/src/opening/mod.rs
+++ b/crates/review-domain/src/opening/mod.rs
@@ -3,7 +3,9 @@
 mod card;
 mod edge;
 mod edge_input;
+mod graph;
 
 pub use card::OpeningCard;
 pub use edge::OpeningEdge;
 pub use edge_input::EdgeInput;
+pub use graph::{OpeningGraph, PositionNode};

--- a/crates/review-domain/tests/opening_graph_legacy.rs
+++ b/crates/review-domain/tests/opening_graph_legacy.rs
@@ -1,0 +1,88 @@
+use review_domain::RepertoireMove;
+use review_domain::opening::{EdgeInput, OpeningGraph};
+use serde_json::json;
+
+#[test]
+fn opening_graph_flattens_to_legacy_edges_snapshot() {
+    let edges: Vec<_> = vec![
+        EdgeInput {
+            parent_id: 1,
+            move_uci: "e2e4".to_string(),
+            move_san: "e4".to_string(),
+            child_id: 2,
+        }
+        .into_edge(),
+        EdgeInput {
+            parent_id: 2,
+            move_uci: "g1f3".to_string(),
+            move_san: "Nf3".to_string(),
+            child_id: 3,
+        }
+        .into_edge(),
+        EdgeInput {
+            parent_id: 2,
+            move_uci: "f1c4".to_string(),
+            move_san: "Bc4".to_string(),
+            child_id: 4,
+        }
+        .into_edge(),
+    ];
+
+    let graph = OpeningGraph::from_edges(edges.clone());
+    let legacy_moves = graph.legacy_moves();
+
+    let expected: Vec<RepertoireMove> = edges
+        .into_iter()
+        .map(|edge| {
+            RepertoireMove::new(
+                edge.id,
+                edge.parent_id,
+                edge.child_id,
+                edge.move_uci,
+                edge.move_san,
+            )
+        })
+        .collect();
+
+    let expected_json: Vec<_> = expected
+        .iter()
+        .map(|mv| {
+            json!({
+                "edge_id": mv.edge_id,
+                "parent_id": mv.parent_id,
+                "child_id": mv.child_id,
+                "move_uci": mv.move_uci,
+                "move_san": mv.move_san,
+            })
+        })
+        .collect();
+
+    insta::assert_json_snapshot!(
+        &expected_json,
+        @r###"[
+  {
+    "child_id": 2,
+    "edge_id": 14975286395967137125,
+    "move_san": "e4",
+    "move_uci": "e2e4",
+    "parent_id": 1
+  },
+  {
+    "child_id": 3,
+    "edge_id": 804340966091102782,
+    "move_san": "Nf3",
+    "move_uci": "g1f3",
+    "parent_id": 2
+  },
+  {
+    "child_id": 4,
+    "edge_id": 4389009945857421815,
+    "move_san": "Bc4",
+    "move_uci": "f1c4",
+    "parent_id": 2
+  }
+]"###
+    );
+
+    assert_eq!(legacy_moves, expected);
+}


### PR DESCRIPTION
## Summary
- add an `opening::graph` module that stores adjacency and recreates the legacy edge list
- cover the serializer with an insta snapshot test that guards deterministic output
- adjust supporting exports, dependencies, and pedantic tests to keep the workspace lint clean

## Testing
- `cargo test -p review-domain opening_graph_flattens_to_legacy_edges_snapshot`
- `make test` *(fails: existing web-ui lint violations unrelated to the new code)*

------
https://chatgpt.com/codex/tasks/task_e_68ec129f99148325a0f2efe319ef7628