### PR TITLE
Fix lint errors in application service type definitions

### DIFF
--- a/web-ui/src/application/controllers/OpeningReviewController.ts
+++ b/web-ui/src/application/controllers/OpeningReviewController.ts
@@ -31,12 +31,14 @@ export type OpeningReviewEvent =
   | { type: 'status'; status: OpeningReviewStatus }
   | { type: 'error'; message: string };
 
-export interface OpeningReviewController {
-  getSnapshot(): OpeningReviewSnapshot;
-  selectSquare(square: string): void;
-  dropPiece(from: string, to: string): void;
-  submitGrade(grade: ReviewGrade): Promise<void>;
-  loadLine(lineId: string): Promise<void>;
-  reset(): void;
-  subscribe(listener: (snapshot: OpeningReviewSnapshot, event?: OpeningReviewEvent) => void): () => void;
-}
+export type OpeningReviewController = {
+  getSnapshot: () => OpeningReviewSnapshot;
+  selectSquare: (square: string) => void;
+  dropPiece: (from: string, to: string) => void;
+  submitGrade: (grade: ReviewGrade) => Promise<void>;
+  loadLine: (lineId: string) => Promise<void>;
+  reset: () => void;
+  subscribe: (
+    listener: (snapshot: OpeningReviewSnapshot, event?: OpeningReviewEvent) => void,
+  ) => () => void;
+};

--- a/web-ui/src/application/controllers/SessionController.ts
+++ b/web-ui/src/application/controllers/SessionController.ts
@@ -22,12 +22,12 @@ export type SessionSnapshot = {
   error?: string;
 };
 
-export interface SessionController {
-  getSnapshot(): SessionSnapshot;
-  subscribe(listener: (snapshot: SessionSnapshot) => void): () => void;
-  start(): Promise<void>;
-  startDemo(): Promise<void>;
-  submitGrade(grade: ReviewGrade, latencyMs: number): Promise<void>;
-  preloadNext(): Promise<void>;
-  reset(): void;
-}
+export type SessionController = {
+  getSnapshot: () => SessionSnapshot;
+  subscribe: (listener: (snapshot: SessionSnapshot) => void) => () => void;
+  start: () => Promise<void>;
+  startDemo: () => Promise<void>;
+  submitGrade: (grade: ReviewGrade, latencyMs: number) => Promise<void>;
+  preloadNext: () => Promise<void>;
+  reset: () => void;
+};

--- a/web-ui/src/application/services/CommandPaletteService.ts
+++ b/web-ui/src/application/services/CommandPaletteService.ts
@@ -20,13 +20,16 @@ export type CommandExecution = {
 
 export type CommandHandler = (
   context: CommandContext,
-) => Promise<CommandExecution | void> | CommandExecution | void;
+) => Promise<CommandExecution | undefined> | CommandExecution | undefined;
 
-export interface CommandPaletteService {
-  register(command: CommandRegistration, handler: CommandHandler): void;
-  unregister(commandId: string): void;
-  list(): CommandRegistration[];
-  execute(commandId: string, context?: Partial<CommandContext>): Promise<CommandExecution>;
-  subscribe(listener: (execution: CommandExecution) => void): () => void;
-  reset(): void;
-}
+export type CommandPaletteService = {
+  register: (command: CommandRegistration, handler: CommandHandler) => void;
+  unregister: (commandId: string) => void;
+  list: () => CommandRegistration[];
+  execute: (
+    commandId: string,
+    context?: Partial<CommandContext>,
+  ) => Promise<CommandExecution>;
+  subscribe: (listener: (execution: CommandExecution) => void) => () => void;
+  reset: () => void;
+};

--- a/web-ui/src/application/services/ImportPlanner.ts
+++ b/web-ui/src/application/services/ImportPlanner.ts
@@ -9,8 +9,8 @@ export type ImportPlan = {
   messages: string[];
 };
 
-export interface ImportPlanner {
-  planLine(line: DetectedOpeningLine, referenceDate?: Date): ImportPlan;
-  planBulk(lines: DetectedOpeningLine[], referenceDate?: Date): ImportPlan[];
-  persist(plan: ImportPlan): Promise<void>;
-}
+export type ImportPlanner = {
+  planLine: (line: DetectedOpeningLine, referenceDate?: Date) => ImportPlan;
+  planBulk: (lines: DetectedOpeningLine[], referenceDate?: Date) => ImportPlan[];
+  persist: (plan: ImportPlan) => Promise<void>;
+};

--- a/web-ui/src/application/services/PgnImportService.ts
+++ b/web-ui/src/application/services/PgnImportService.ts
@@ -28,8 +28,8 @@ export type PgnImportOutcome = {
   errors: string[];
 };
 
-export interface PgnImportService {
-  detect(source: PgnImportSource): Promise<PgnImportOutcome>;
-  acknowledge(outcome: PgnImportOutcome): void;
-  clear(): void;
-}
+export type PgnImportService = {
+  detect: (source: PgnImportSource) => Promise<PgnImportOutcome>;
+  acknowledge: (outcome: PgnImportOutcome) => void;
+  clear: () => void;
+};

--- a/web-ui/src/application/viewModels/DashboardViewModel.ts
+++ b/web-ui/src/application/viewModels/DashboardViewModel.ts
@@ -29,10 +29,10 @@ export type DashboardOverview = {
   stats: SessionStats | null;
 };
 
-export interface DashboardViewModel {
-  load(): Promise<DashboardOverview>;
-  refresh(): Promise<DashboardOverview>;
-  subscribe(listener: (overview: DashboardOverview) => void): () => void;
-  applyImportResults(results: ImportResult[]): void;
-  updateSessionStats(stats: SessionStats): void;
-}
+export type DashboardViewModel = {
+  load: () => Promise<DashboardOverview>;
+  refresh: () => Promise<DashboardOverview>;
+  subscribe: (listener: (overview: DashboardOverview) => void) => () => void;
+  applyImportResults: (results: ImportResult[]) => void;
+  updateSessionStats: (stats: SessionStats) => void;
+};


### PR DESCRIPTION
## Summary
- replace interface-based API contracts with type aliases across application controllers, services, and view models to satisfy lint rules
- align command handler return type with eslint requirements by using `undefined` instead of `void`

## Testing
- npm run lint -- --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68ec305387588325b48dd68014ba6b69