### PR TITLE
Add coverage tests for review-domain helpers

### DIFF
--- a/crates/review-domain/tests/card_state.rs
+++ b/crates/review-domain/tests/card_state.rs
@@ -1,0 +1,34 @@
+use chrono::NaiveDate;
+use review_domain::{StoredCardState, ValidGrade};
+
+fn naive_date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).expect("valid date")
+}
+
+#[test]
+fn next_interval_walks_all_grade_branches() {
+    let interval = std::num::NonZeroU8::new(3).expect("non-zero interval");
+    let state = StoredCardState::new(naive_date(2024, 1, 1), interval, 2.5);
+
+    assert_eq!(state.next_interval(ValidGrade::Zero).get(), 1);
+    assert_eq!(state.next_interval(ValidGrade::One).get(), 1);
+    assert_eq!(state.next_interval(ValidGrade::Two).get(), 3);
+    assert_eq!(state.next_interval(ValidGrade::Three).get(), 4);
+    assert_eq!(state.next_interval(ValidGrade::Four).get(), 6);
+}
+
+#[test]
+fn apply_review_mutates_state_consistently() {
+    let interval = std::num::NonZeroU8::new(2).expect("non-zero interval");
+    let mut state = StoredCardState::new(naive_date(2024, 2, 2), interval, 2.4);
+
+    let review_day = naive_date(2024, 2, 10);
+    state.consecutive_correct = 1;
+    state.apply_review(ValidGrade::Four, review_day);
+
+    assert_eq!(state.interval.get(), 4);
+    assert_eq!(state.due_on, naive_date(2024, 2, 14));
+    assert_eq!(state.last_reviewed_on, Some(review_day));
+    assert_eq!(state.consecutive_correct, 2);
+    assert!(state.ease_factor >= 2.4);
+}

--- a/crates/review-domain/tests/repertoire.rs
+++ b/crates/review-domain/tests/repertoire.rs
@@ -1,3 +1,4 @@
+use review_domain::repertoire::repertoire_::RepertoireBuilder;
 use review_domain::repertoire::{Repertoire, RepertoireError, RepertoireMove};
 
 #[test]
@@ -20,6 +21,43 @@ fn remove_move_stub_returns_expected_error() {
     let mut repertoire = Repertoire::new("queen's gambit");
     let result = repertoire.remove_move(42);
     assert_eq!(result, Err(RepertoireError::not_implemented("remove_move")));
+}
+
+#[test]
+fn builder_supports_composing_repertoire() {
+    let repertoire = RepertoireBuilder::new("builder test")
+        .add_move(RepertoireMove::new(10, 20, 21, "e2e4", "e4"))
+        .extend([RepertoireMove::new(11, 21, 22, "g1f3", "Nf3")])
+        .build();
+
+    assert_eq!(repertoire.name(), "builder test");
+    assert_eq!(repertoire.moves().len(), 2);
+    assert_eq!(repertoire.moves()[0].move_uci, "e2e4");
+    assert_eq!(repertoire.moves()[1].move_san, "Nf3");
+}
+
+#[test]
+fn repertoire_collect_from_iterator_preserves_moves() {
+    let moves = vec![
+        RepertoireMove::new(1, 1, 2, "e2e4", "e4"),
+        RepertoireMove::new(2, 2, 3, "d2d4", "d4"),
+    ];
+
+    let repertoire: Repertoire = moves.clone().into_iter().collect();
+
+    assert_eq!(repertoire.name(), "");
+    assert_eq!(repertoire.moves(), &moves[..]);
+}
+
+#[test]
+fn repertoire_move_constructor_accepts_string_inputs() {
+    let mv = RepertoireMove::new(7, 8, 9, String::from("e7e5"), String::from("...e5"));
+
+    assert_eq!(mv.edge_id, 7);
+    assert_eq!(mv.parent_id, 8);
+    assert_eq!(mv.child_id, 9);
+    assert_eq!(mv.move_uci, "e7e5");
+    assert_eq!(mv.move_san, "...e5");
 }
 
 #[cfg(feature = "serde")]

--- a/crates/review-domain/tests/study_stage_modules.rs
+++ b/crates/review-domain/tests/study_stage_modules.rs
@@ -19,3 +19,25 @@ fn exposes_query_helpers_in_submodule() {
     assert!(queries::is_active(study_stage::StudyStage::Review));
     assert!(!queries::is_active(study_stage::StudyStage::New));
 }
+
+#[test]
+fn query_helpers_cover_all_variants() {
+    use study_stage::StudyStage;
+
+    assert!(queries::is_new(StudyStage::New));
+    assert!(!queries::is_new(StudyStage::Learning));
+
+    assert!(queries::is_learning(StudyStage::Learning));
+    assert!(!queries::is_learning(StudyStage::Review));
+
+    assert!(queries::is_review(StudyStage::Review));
+    assert!(!queries::is_review(StudyStage::New));
+
+    assert!(queries::is_relearning(StudyStage::Relearning));
+    assert!(!queries::is_relearning(StudyStage::Review));
+
+    assert!(queries::is_active(StudyStage::Learning));
+    assert!(queries::is_active(StudyStage::Review));
+    assert!(queries::is_active(StudyStage::Relearning));
+    assert!(!queries::is_active(StudyStage::New));
+}

--- a/crates/review-domain/tests/valid_grade_modules.rs
+++ b/crates/review-domain/tests/valid_grade_modules.rs
@@ -12,6 +12,24 @@ fn conversions_module_exposes_grade_parsing() {
 }
 
 #[test]
+fn conversions_helpers_cover_all_entry_points() {
+    assert_eq!(conversions::new(2), Ok(ValidGrade::Two));
+    assert!(matches!(
+        conversions::new(9),
+        Err(GradeError::GradeOutsideRangeError { grade: 9 })
+    ));
+
+    let grade = ValidGrade::Three;
+    assert_eq!(conversions::as_u8(grade), 3);
+    assert_eq!(grade.to_u8(), 3);
+    assert_eq!(grade.as_u8(), 3);
+
+    assert_eq!(ValidGrade::from_u8(4), Ok(ValidGrade::Four));
+    assert_eq!(ValidGrade::new(1), Ok(ValidGrade::One));
+    assert_eq!(ValidGrade::try_from(0_u8), Ok(ValidGrade::Zero));
+}
+
+#[test]
 fn accuracy_and_interval_modules_share_responsibilities() {
     assert!(accuracy::is_correct(ValidGrade::Four));
     assert_eq!(intervals::to_interval_increment(ValidGrade::Three), 2);


### PR DESCRIPTION
## Summary
- add integration tests exercising `StoredCardState` interval and review updates
- extend repertoire tests to cover builder construction, iterator collection, and move constructors
- broaden grade conversion and study stage query tests to touch every helper

## Testing
- `cargo test -p review-domain`
- `make test` *(fails: existing web-ui eslint rules requiring type aliases and non-shorthand method signatures)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2fcbea5c83259fb1f61077e3b953