### PR TITLE
Rename card-store card id helpers

### DIFF
--- a/crates/card-store/src/memory/in_memory_card_store.rs
+++ b/crates/card-store/src/memory/in_memory_card_store.rs
@@ -6,7 +6,6 @@ use std::{
 use chrono::NaiveDate;
 
 use crate::{
-    CardStore, StoreError,
     chess_position::ChessPosition,
     config::StorageConfig,
     memory::{
@@ -15,9 +14,10 @@ use crate::{
         store_canonical_position, store_opening_card,
     },
     model::{
-        Card, CardMap, Edge, EdgeInput, EdgeMap, PositionMap, ReviewRequest, StoredCardState,
-        UnlockRecord, UnlockSet, card_id_for_opening,
+        build_opening_card_id, Card, CardMap, Edge, EdgeInput, EdgeMap, PositionMap, ReviewRequest,
+        StoredCardState, UnlockRecord, UnlockSet,
     },
+    CardStore, StoreError,
 };
 
 /// Thread-safe in-memory reference implementation of the storage trait.
@@ -134,7 +134,7 @@ impl CardStore for InMemoryCardStore {
         state: StoredCardState,
     ) -> Result<Card, StoreError> {
         self.ensure_edge_exists(edge.id)?;
-        let card_id = card_id_for_opening(owner_id, edge.id);
+        let card_id = build_opening_card_id(owner_id, edge.id);
         let mut cards = self.cards_write()?;
         store_opening_card(&mut cards, owner_id, edge, state, card_id)
     }

--- a/crates/card-store/src/model.rs
+++ b/crates/card-store/src/model.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 /// Re-export shared review-domain types to simplify crate consumers.
 pub use review_domain::{EdgeInput, OpeningCard, ReviewRequest, StoredCardState, TacticCard};
 pub use scheduler_core::domain::{
-    CardStateBridgeError, Sm2Runtime, StoredSnapshot, hydrate_sm2_state, persist_sm2_state,
+    hydrate_sm2_state, persist_sm2_state, CardStateBridgeError, Sm2Runtime, StoredSnapshot,
 };
 
 use review_domain::{
@@ -44,13 +44,13 @@ pub type UnlockRecord = GenericUnlockRecord<String, UnlockDetail>;
 
 /// Deterministically compute a card identifier for an opening edge.
 #[must_use]
-pub fn card_id_for_opening(owner_id: &str, edge_id: u64) -> u64 {
+pub fn build_opening_card_id(owner_id: &str, edge_id: u64) -> u64 {
     hash64(&[owner_id.as_bytes(), &edge_id.to_be_bytes()])
 }
 
 /// Deterministically compute a card identifier for a tactic.
 #[must_use]
-pub fn card_id_for_tactic(owner_id: &str, tactic_id: u64) -> u64 {
+pub fn build_tactic_card_id(owner_id: &str, tactic_id: u64) -> u64 {
     hash64(&[owner_id.as_bytes(), &tactic_id.to_be_bytes()])
 }
 
@@ -73,17 +73,17 @@ mod tests {
     }
 
     #[test]
-    fn card_id_for_tactic_depends_on_inputs() {
-        let base = card_id_for_tactic("owner", 42);
-        assert_ne!(base, card_id_for_tactic("owner", 43));
-        assert_ne!(base, card_id_for_tactic("other", 42));
+    fn build_tactic_card_id_depends_on_inputs() {
+        let base = build_tactic_card_id("owner", 42);
+        assert_ne!(base, build_tactic_card_id("owner", 43));
+        assert_ne!(base, build_tactic_card_id("other", 42));
     }
 
     #[test]
-    fn card_id_for_opening_depends_on_inputs() {
-        let base = card_id_for_opening("owner", 7);
-        assert_ne!(base, card_id_for_opening("owner", 8));
-        assert_ne!(base, card_id_for_opening("other", 7));
+    fn build_opening_card_id_depends_on_inputs() {
+        let base = build_opening_card_id("owner", 7);
+        assert_ne!(base, build_opening_card_id("owner", 8));
+        assert_ne!(base, build_opening_card_id("other", 7));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- rename the deterministic card helper functions to build_opening_card_id/build_tactic_card_id
- update the in-memory card store and unit tests to use the new helper names
- refresh the naming audit documentation to reference the new builders

## Testing
- rustfmt crates/card-store/src/model.rs crates/card-store/src/memory/in_memory_card_store.rs
- cargo test -p card-store *(fails: review-domain card_aggregate.rs currently has an unclosed delimiter)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf890b99083259f907c6fb1a626fd