### PR TITLE
Rename wasm queue length binding for scheduler

### DIFF
--- a/crates/scheduler-wasm/CHANGELOG.md
+++ b/crates/scheduler-wasm/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Rename the exported wasm binding from `buildQueueLength` to `queueLength` to match `SchedulerFacade::queue_length` and align JavaScript consumers with the Rust API.

--- a/crates/scheduler-wasm/src/bindings.rs
+++ b/crates/scheduler-wasm/src/bindings.rs
@@ -41,8 +41,8 @@ impl WasmScheduler {
     }
 
     /// Builds the queue for the provided owner and reports the number of cards.
-    #[wasm_bindgen(js_name = "buildQueueLength")]
-    pub fn build_queue_length(&mut self, owner_id: &str, iso_date: &str) -> Result<u32, JsValue> {
+    #[wasm_bindgen(js_name = "queueLength")]
+    pub fn queue_length(&mut self, owner_id: &str, iso_date: &str) -> Result<u32, JsValue> {
         let owner_id = parse_owner_id(owner_id)?;
         let today = parse_iso_date(iso_date)?;
         let length = self.facade.queue_length(owner_id, today);

--- a/docs/rust-structs-glossary.md
+++ b/docs/rust-structs-glossary.md
@@ -343,7 +343,7 @@ pub struct WasmScheduler {
 _Source:_ `crates/scheduler-wasm/src/bindings.rs`
 
 **Usage in this repository:**
-- The wasm bindings expose `WasmScheduler::build_queue_length` to JavaScript, allowing the web UI to request queue sizes without handling raw Rust types.
+- The wasm bindings expose `WasmScheduler::queue_length` to JavaScript, allowing the web UI to request queue sizes without handling raw Rust types.
 - `WasmScheduler::new` applies `SchedulerConfigPatch` values so JS callers can override defaults when initializing the module.
 
 ### `SchedulerConfigDto`

--- a/repo-naming-standards.md
+++ b/repo-naming-standards.md
@@ -34,7 +34,7 @@ Use verbs consistently to signal how an API behaves. When adding a new function,
 | Convert types without consuming | `as_*`, `to_*` | Follow Rust idioms: `to_*` returns owned data, `as_*` returns borrowed/cast views. | `Grade::to_u8`, `Grade::as_u8`. |
 | Persist or update storage | `upsert_*`, `record_*` | Avoid mixing `store_*`, `insert_*`, `save_*` for the same action. Pick the dominant verb in the module/crate and use it everywhere. | `upsert_canonical_position`, `record_unlock`. |
 | Read-only queries | `get_*`, `load_*`, `fetch_*` | Prefer a single verb per module (`get` vs `fetch`). Avoid `collect_*` unless building a derived collection. | `get_due_cards_for_owner`. |
-| Queue or workflow building | `build_*`, `prepare_*` | Avoid mixing `build_queue` with `build_queue_length`; expose `queue_len` for size checks. | `build_queue_for_day`, `queue_len`. |
+| Queue or workflow building | `build_*`, `prepare_*` | Avoid mixing `build_queue` with queue-length names; expose `queue_length` for size checks. | `build_queue_for_day`, `queue_length`. |
 
 ## Structs, Enums, and Type Aliases
 [Back to Top](#repository-naming-standards)
@@ -63,7 +63,7 @@ Use verbs consistently to signal how an API behaves. When adding a new function,
 [Back to Top](#repository-naming-standards)
 
 - **Align shared concepts.** If a name appears in multiple crates, use the same spelling and suffix (`CardStore` vs. `SchedulerCardStore`). Consider renaming conflicting traits per the audit recommendations to avoid double imports.
-- **Queue terminology.** Export `queue`-related functions with matching verbs across crates (`queue_len`, `build_queue`). Avoid introducing `build_queue_length` variations.
+- **Queue terminology.** Export `queue`-related functions with matching verbs across crates (`queue_length`, `build_queue`). Avoid introducing mismatched verb+noun hybrids.
 - **In-memory stores.** Standardize on `InMemory*Store` (`InMemoryCardStore`, `InMemoryImportStore`, `InMemorySchedulerStore`).
 - **Unlock flow.** Harmonize verbs between crates so card-store and scheduler both use `record_unlock` or `upsert_unlock`, not a mix of `insert`/`record`.
 
@@ -79,7 +79,7 @@ Use verbs consistently to signal how an API behaves. When adding a new function,
 
 Use this checklist when touching names:
 
-1. **Audit existing usage.** Search the repo (e.g., `rg "build_queue_length"`) to understand current patterns before changing anything.
+1. **Audit existing usage.** Search the repo (e.g., `rg "queue_length"`) to understand current patterns before changing anything.
 2. **Select verbs/nouns per this guide.** Ensure new names align with the tables and conventions above.
 3. **Update related items together.** When renaming a trait, adjust implementations, docs, and re-exports in the same change.
 4. **Refresh documentation.** Update this standard and the glossary when the repo’s naming expectations evolve.

--- a/rust-naming-audit.md
+++ b/rust-naming-audit.md
@@ -195,16 +195,16 @@ These items orchestrate SM-2 reviews, queue construction, and unlock tracking.
   - Assemble the daily review queue, merging due cards with unlocks and preventing duplicates.
   - *Related items:* `queue_length` in wasm calls into these helpers. Verb prefixes vary between `build_`, `extend_`, `skip_`, `unlock_`, which match their roles.
 
-- **`queue_length`** (`crates/scheduler-wasm/src/scheduler.rs`) & **`build_queue_length`** (`crates/scheduler-wasm/src/bindings.rs`)
-  - Provide wasm-friendly access to queue sizes.
-  - *Related items:* `build_queue_for_day`. Mixed naming (`queue_length` vs. `build_queue_length`) could standardize on `queue_length`.
+- **`queue_length`** (`crates/scheduler-wasm/src/scheduler.rs` and `crates/scheduler-wasm/src/bindings.rs`)
+  - Provide wasm-friendly access to queue sizes with consistent naming across the facade and bindings.
+  - *Related items:* `build_queue_for_day`. Naming now lines up with scheduler internals, keeping verbs focused on queue building while lengths use the shared noun phrase.
 
 - **Unlock handling**
   - `SchedulerUnlockDetail`, `UnlockRecord` alias (`crates/scheduler-core/src/domain/mod.rs`), scheduler store methods (`record_unlock`, `unlock_candidates`), and wasm binding helpers (`default_config`, `init_panic_hook` for environment setup).
   - *Related items:* `insert_unlock_or_error` (card-store). Method names `record_*` vs. `insert_*` highlight cross-crate inconsistency.
 
 **Naming observations for this group:**
-- `build_queue_length` vs. `queue_length` is an easy win—rename the wasm binding to `queue_length` or `queue_size` for clarity.
+- Continue to audit wasm exports when scheduler APIs change so naming alignment persists across Rust facades and bindings.
 - Scheduler store methods like `due_cards_for_owner` could align with card-store’s `collect_due_cards_for_owner` by picking either `due_cards` or `collect_due_cards` across crates.
 
 ---


### PR DESCRIPTION
## Summary
- rename the WasmScheduler binding to `queue_length`/`queueLength` so it lines up with `SchedulerFacade::queue_length`
- update documentation and naming guidance that referenced `build_queue_length`
- add a scheduler-wasm changelog entry noting the API rename for downstream consumers

## Testing
- `cargo test -p scheduler-wasm` *(fails: existing syntax error in crates/review-domain/src/card_aggregate.rs prevents compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf8bdcbdc83259ea3148368bf6df7