### PR TITLE
Rename PGN CLI config builder method

### DIFF
--- a/crates/chess-training-pgn-import/src/config.rs
+++ b/crates/chess-training-pgn-import/src/config.rs
@@ -217,13 +217,13 @@ impl CliArgs {
             .map(|matches| Self::from_matches(&matches))
     }
 
-    /// Converts the parsed CLI arguments into the runtime configuration and remaining inputs.
+    /// Builds the runtime configuration and remaining inputs from the parsed CLI arguments.
     ///
     /// # Errors
     ///
     /// Returns an error if a configuration file is requested but cannot be read or parsed,
     /// or if no PGN inputs are supplied after merging CLI and file sources.
-    pub fn into_ingest_config(self) -> ConfigResult<(IngestConfig, Vec<PathBuf>)> {
+    pub fn build_ingest_config(self) -> ConfigResult<(IngestConfig, Vec<PathBuf>)> {
         let CliArgs {
             inputs,
             config_file,

--- a/crates/chess-training-pgn-import/tests/config_cli.rs
+++ b/crates/chess-training-pgn-import/tests/config_cli.rs
@@ -17,7 +17,7 @@ fn cli_parses_inputs_with_default_config() {
     .expect("CLI parsing should succeed");
 
     let (config, inputs) = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect("CLI conversion should succeed");
 
     assert_eq!(
@@ -36,7 +36,7 @@ fn cli_requires_at_least_one_input() {
         .expect("parsing should succeed to allow config-file usage");
 
     let err = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect_err("conversion should fail when no inputs are provided");
 
     let is_no_inputs = |error: &ConfigError| matches!(error, ConfigError::NoInputs);
@@ -74,7 +74,7 @@ fn cli_applies_boolean_and_depth_overrides() {
     .expect("CLI parsing should succeed with overrides");
 
     let (config, inputs) = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect("CLI conversion should succeed with overrides");
 
     assert_eq!(inputs, vec![PathBuf::from("games/foo.pgn")]);
@@ -142,7 +142,7 @@ tactic_from_fen = false
     .expect("CLI parsing should succeed with config file");
 
     let (config, inputs) = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect("loader should merge file and CLI sources");
 
     assert_eq!(
@@ -183,7 +183,7 @@ fn config_loader_reports_io_errors_with_context() {
     .expect("CLI parsing should allow nonexistent config paths");
 
     let err = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect_err("missing file should surface as an IO error");
 
     if let ConfigError::Io(io_error) = &err {
@@ -229,7 +229,7 @@ fn config_loader_reports_parse_errors_with_context() {
     .expect("CLI parsing should allow invalid config contents");
 
     let err = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect_err("invalid TOML should surface as a parse error");
 
     if let ConfigError::Parse(parse_error) = &err {
@@ -280,7 +280,7 @@ max_rav_depth = 5
     .expect("CLI parsing should succeed when relying on config inputs");
 
     let (config, inputs) = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect("config file should supply inputs and flags");
 
     assert_eq!(inputs, vec![PathBuf::from("config-only.pgn")]);
@@ -318,7 +318,7 @@ fn config_loader_handles_missing_optional_fields() {
     .expect("CLI parsing should succeed with config defaults");
 
     let (config, inputs) = cli
-        .into_ingest_config()
+        .build_ingest_config()
         .expect("loader should allow missing optional fields");
 
     assert_eq!(inputs, vec![PathBuf::from("cli-only.pgn")]);

--- a/docs/rust-structs-glossary.md
+++ b/docs/rust-structs-glossary.md
@@ -873,7 +873,7 @@ _Source:_ `crates/chess-training-pgn-import/src/config.rs`
 
 **Usage in this repository:**
 - `Importer::new` stores an `IngestConfig` copy to decide whether to record positions, tactics, or skip malformed FEN games.
-- `CliArgs::into_ingest_config` mutates `IngestConfig` based on CLI flags and configuration files, demonstrating how multiple configuration sources converge.
+- `CliArgs::build_ingest_config` mutates `IngestConfig` based on CLI flags and configuration files, demonstrating how multiple configuration sources converge.
 
 ### `FileConfig`
 
@@ -895,8 +895,8 @@ struct FileConfig {
 _Source:_ `crates/chess-training-pgn-import/src/config.rs`
 
 **Usage in this repository:**
-- `FileConfig::from_path` reads TOML files, turning them into optional overrides that `CliArgs::into_ingest_config` merges with CLI flags.
-- When inputs are provided via config file, `into_ingest_config` appends them to CLI-specified paths, ensuring both sources are respected.
+- `FileConfig::from_path` reads TOML files, turning them into optional overrides that `CliArgs::build_ingest_config` merges with CLI flags.
+- When inputs are provided via config file, `build_ingest_config` appends them to CLI-specified paths, ensuring both sources are respected.
 
 ### `CliArgs`
 
@@ -920,12 +920,12 @@ _Source:_ `crates/chess-training-pgn-import/src/config.rs`
 
 **Usage in this repository:**
 - `CliArgs::try_parse_from` builds the CLI using clap and parses arguments provided by integration tests or binaries.
-- `CliArgs::into_ingest_config` validates that at least one PGN input is provided (raising `ConfigError::NoInputs` otherwise) and merges CLI plus file-driven configuration.
+- `CliArgs::build_ingest_config` validates that at least one PGN input is provided (raising `ConfigError::NoInputs` otherwise) and merges CLI plus file-driven configuration.
 
 **Mermaid diagram:**
 ```mermaid
 flowchart LR
-    CLI[CliArgs] -->|into_ingest_config| CFG[IngestConfig]
+    CLI[CliArgs] -->|build_ingest_config| CFG[IngestConfig]
     FileConfig -->|overrides| CFG
     CFG -->|controls| Importer
     Importer -->|produces| Metrics[ImportMetrics]

--- a/repo-naming-standards.md
+++ b/repo-naming-standards.md
@@ -29,7 +29,7 @@ Use verbs consistently to signal how an API behaves. When adding a new function,
 
 | Intent | Preferred Verb(s) | Avoid / Notes | Example |
 | ------ | ----------------- | ------------- | ------- |
-| Build a new value without side effects | `new_*`, `build_*`, `create_*` | Avoid `make_*` and `into_*` for constructors. `into_*` implies type conversion that consumes `self`. | `build_ingest_config` (preferred over `into_ingest_config`). |
+| Build a new value without side effects | `new_*`, `build_*`, `create_*` | Avoid `make_*` and `into_*` for constructors. `into_*` implies type conversion that consumes `self`. | `build_ingest_config`. |
 | Convert types while consuming the source | `into_*` | Only use when the method takes ownership and converts to another type. | `EdgeInput::into_edge`. |
 | Convert types without consuming | `as_*`, `to_*` | Follow Rust idioms: `to_*` returns owned data, `as_*` returns borrowed/cast views. | `Grade::to_u8`, `Grade::as_u8`. |
 | Persist or update storage | `upsert_*`, `record_*` | Avoid mixing `store_*`, `insert_*`, `save_*` for the same action. Pick the dominant verb in the module/crate and use it everywhere. | `upsert_canonical_position`, `record_unlock`. |

--- a/rust-naming-audit.md
+++ b/rust-naming-audit.md
@@ -12,7 +12,7 @@ These types centralize tunable knobs, offer defaults, or translate user input (f
   - Stores connection pool limits, batching, and retry counts for card-store backends so deployments can tune persistence without code changes.
   - *Related items:* `SchedulerConfig` (SM-2 tuning), `IngestConfig` (PGN importer knobs), `SchedulerConfigDto`/`SchedulerConfigPatch` (wasm serialization/patching), `FileConfig` and `CliArgs` (PGN CLI).
 
-- **`IngestConfig`**, **`FileConfig::from_path`**, **`CliArgs::{command, from_matches, try_parse_from, into_ingest_config}`** (`crates/chess-training-pgn-import/src/config.rs`)
+- **`IngestConfig`**, **`FileConfig::from_path`**, **`CliArgs::{command, from_matches, try_parse_from, build_ingest_config}`** (`crates/chess-training-pgn-import/src/config.rs`)
   - Collect configuration inputs from TOML and command line, ensuring PGN ingestion has all required flags and default fallbacks.
   - *Related items:* `Importer::new` uses these settings; `SchedulerFacade::new` and `WasmScheduler::new` also merge optional patches before instantiating services.
 
@@ -33,7 +33,7 @@ These types centralize tunable knobs, offer defaults, or translate user input (f
   - *Related items:* tests guarding they don’t panic; all of these share placeholder naming and could eventually converge on `fn run()` helpers for consistency.
 
 **Naming observations for this group:**
-- Config structs consistently end with `Config`, but helper methods vary between `from_matches`, `try_parse_from`, `apply`, and `into_ingest_config`. They follow domain idioms, yet the CLI pipeline mixes `into_*` and `from_*` verbs. Consider renaming `CliArgs::into_ingest_config` to `build_ingest_config` to mirror other builders.
+- Config structs consistently end with `Config`, but helper methods vary between `from_matches`, `try_parse_from`, `apply`, and `build_ingest_config`. They follow domain idioms, yet the CLI pipeline mixes `into_*` and `from_*` verbs; adopting builder verbs (like `build_ingest_config`) keeps constructors consistent.
 
 ---
 


### PR DESCRIPTION
## Summary
- rename `CliArgs::into_ingest_config` to the builder-style `build_ingest_config`
- update importer tests and documentation references to use the new method name
- refresh naming guidance to highlight the builder verb in the glossary and standards

## Testing
- `cargo fmt -p chess-training-pgn-import`
- `cargo test -p chess-training-pgn-import` *(fails: `review-domain` crate reports an unclosed delimiter in `card_aggregate.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf882c9608325ad370a0bddc5bdc2