### PR TITLE
Fix review-domain card aggregate implementation

### DIFF
--- a/crates/review-domain/tests/card_aggregate.rs
+++ b/crates/review-domain/tests/card_aggregate.rs
@@ -3,7 +3,8 @@ use std::num::NonZeroU8;
 use chrono::NaiveDate;
 
 use review_domain::{
-    CardAggregate, CardKind, EdgeId, OpeningCard, StoredCardState, TacticCard, ValidGrade,
+    CardAggregate, CardKind, EdgeId, GradeError, OpeningCard, ReviewRequest, StoredCardState,
+    TacticCard, ValidGrade,
 };
 
 fn naive_date(year: i32, month: u32, day: u32) -> NaiveDate {


### PR DESCRIPTION
## Summary
- clean up the card aggregate module by removing the stray duplicate definition and restoring the closing delimiter
- extend the concrete aggregate with review helper methods while accepting any `EdgeId`-convertible value for openings
- update the integration test imports to compile with the revised aggregate API

## Testing
- `cargo test -p review-domain` *(fails: existing repertoire integration tests require additional imports and conversions for typed identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_68ecfb84edf48325827866eb6ba79fa9