### PR TITLE
Document quiz engine acceptance criteria backlog

### DIFF
--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -2,9 +2,9 @@
 
 This plan translates the chess quiz engine design brief and the surrounding repository conventions into a concrete sequence of deliverables. Each task documents the primary inputs we depend upon and the tangible outputs that signal completion. The tasks are ordered to support strict red–green-refactor development and to keep parallel contributors coordinated.
 
-## 1. Finalise acceptance criteria and red tests
+## 1. Finalise acceptance criteria and red tests ✅
 - **Inputs:** `documentation/chess-quiz-engine.md` solution overview, repository TDD policy, existing PGN parsing behaviors in `crates/chess-training-pgn-import`.
-- **Outputs:** A living checklist of acceptance criteria (single-line PGN scope, retry policy, feedback messaging, adapter isolation) plus an ordered backlog of failing tests to write first (parser errors, retry exhaustion, summary math). Publish in `documentation/chess-quiz-engine.md` or `docs/` for team visibility.
+- **Outputs:** A living checklist of acceptance criteria (single-line PGN scope, retry policy, feedback messaging, adapter isolation) plus an ordered backlog of failing tests to write first (parser errors, retry exhaustion, summary math). Published in `documentation/chess-quiz-engine.md` under “Acceptance Criteria Checklist” and “Initial Red Test Backlog”.
 
 ## 2. Scaffold the `quiz-core` crate and workspace wiring
 - **Inputs:** Workspace `Cargo.toml`, Makefile conventions, design decision to host adapters behind feature flags.


### PR DESCRIPTION
## Summary
- add an acceptance criteria checklist to the chess quiz engine brief covering PGN scope, retries, feedback, and adapter isolation
- outline the initial ordered backlog of red tests for parser validation, retry exhaustion, and summary math
- mark task 1 of the execution plan complete and reference the new documentation sections

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68efa6efb0d08325875f1bc190f463f9

## Summary by Sourcery

Add acceptance criteria and initial red test backlog to chess-quiz-engine documentation and mark the first execution plan task as complete

Documentation:
- Add acceptance criteria checklist covering PGN scope, retry policy, feedback messaging, and adapter isolation
- Outline initial red test backlog for parser validation, retry exhaustion, and summary math

Chores:
- Mark the first task as completed and update its publication details in the execution plan