### PR TITLE
Document quiz-core placeholders

### DIFF
--- a/crates/quiz-core/README.md
+++ b/crates/quiz-core/README.md
@@ -1,0 +1,42 @@
+# `quiz-core`
+
+The `quiz-core` crate owns the domain logic for running interactive chess quizzes. It is designed
+so the core engine can execute without being tied to any particular delivery mechanism. Adapters
+(such as terminal, HTTP API, or WASM front-ends) integrate through narrow port traits while feature
+flags ensure only the code relevant to a build target is compiled.
+
+## Architecture boundaries
+
+The crate is organised around a small set of modules that mirror the execution plan:
+
+- `engine`: will house the orchestration loop that coordinates prompts, attempts, retries, and
+  session summaries.
+- `state`: will model immutable quiz session snapshots, including per-move prompts, attempt
+  tracking, and scoring details.
+- `ports`: will define the adapter-facing traits and message types used by the engine to exchange
+  prompts and feedback with external systems.
+- `errors`: will collect the error taxonomy shared across the engine, state builders, and adapters.
+
+Each module currently exposes placeholders and documentation so downstream contributors understand
+where future implementations belong. As functionality lands, this README should be updated with
+links to concrete types and diagrams that clarify responsibilities between modules.
+
+## Feature gating strategy
+
+The crate ships without default features enabled. Consumers explicitly opt into the adapters they
+need via the following feature flags:
+
+- `cli`: compiles the reference terminal adapter and its supporting binary at `src/bin/cli.rs`.
+- `api`: enables the HTTP/API adapter surface together with the `src/bin/api.rs` binary.
+- `wasm`: enables the WebAssembly adapter surface together with the `src/bin/wasm.rs` binary.
+
+This layout allows lightweight builds (e.g., for server-side batch processing) while keeping adapter
+code isolated. Additional features should follow the same pattern: guard adapter-specific code with
+a named feature flag and add a corresponding binary target only when the feature is enabled.
+
+## Documentation roadmap
+
+- Update this README with concrete examples once the engine APIs are implemented.
+- Cross-link the module documentation with the glossary entries in `docs/rust-structs-glossary.md`
+  so contributors can quickly discover type definitions and invariants.
+- Record adapter-specific considerations (I/O, threading, async boundaries) as those surfaces solidify.

--- a/docs/rust-structs-glossary.md
+++ b/docs/rust-structs-glossary.md
@@ -1054,3 +1054,65 @@ _Source:_ `crates/scheduler-core/tests/opening_scheduling.rs`
 - Opening scheduling tests set availability dates via `insert_with_availability` and advance time with `set_day` to ensure unlock pacing respects day boundaries.
 - By implementing `SchedulerStore`, `TimedStore` plugs directly into queue-building helpers, letting tests assert on queue contents without modifying production code.
 
+
+## Quiz Engine Core
+
+### `QuizEngine`
+
+**Overview:** Planned orchestrator responsible for executing quiz sessions against a provided
+question source and adapter port. Implementation pending while session state and port contracts are
+defined.
+
+**Definition:**
+```
+// implementation pending in `crates/quiz-core/src/engine.rs`
+```
+
+**Usage in this repository:**
+- Will coordinate quiz execution loops, advancing through prompts, recording attempts, and producing
+  session summaries once implemented.
+- Will expose constructors such as `QuizEngine::from_pgn` that prepare state from a PGN source.
+
+### `QuizSession`
+
+**Overview:** Upcoming representation of an immutable quiz session snapshot used by the engine to
+track prompts, retries, and scoring metadata. Implementation pending until the session modelling
+task lands.
+
+**Definition:**
+```
+// implementation pending in `crates/quiz-core/src/state.rs`
+```
+
+**Usage in this repository:**
+- Will carry move-by-move context (FEN/SAN pairs) consumed by the engine and adapters.
+- Will provide helpers for aggregating session summaries and retry counters.
+
+### `QuizError`
+
+**Overview:** Planned error enumeration unifying parsing, state management, and adapter failures in
+the quiz engine. Implementation pending until error boundaries are finalised.
+
+**Definition:**
+```
+// implementation pending in `crates/quiz-core/src/errors.rs`
+```
+
+**Usage in this repository:**
+- Will surface descriptive failure modes to adapters, including PGN issues and retry exhaustion.
+- Will standardise conversions from lower-level libraries (e.g., `shakmaty`) into quiz-specific
+  error variants.
+
+### `FeedbackMessage`
+
+**Overview:** Placeholder for the adapter-facing message type the engine will emit after each
+attempt. Implementation pending while interaction ports are defined.
+
+**Definition:**
+```
+// implementation pending in `crates/quiz-core/src/ports.rs`
+```
+
+**Usage in this repository:**
+- Will convey graded attempt feedback (correctness, hints, retry availability) to UI adapters.
+- Will help keep adapter implementations isolated from internal scoring state.

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -10,9 +10,9 @@ This plan translates the chess quiz engine design brief and the surrounding repo
 - **Inputs:** Workspace `Cargo.toml`, Makefile conventions, design decision to host adapters behind feature flags.
 - **Outputs:** `crates/quiz-core` library with `engine`, `state`, `ports`, and `errors` modules stubbed; feature declarations for `cli`, `api`, and `wasm` with an empty default feature set; placeholder binaries under `src/bin/` compiled only when their feature is enabled via `#![cfg(feature = "...")]`; workspace manifests already glob `crates/*`, so no additional wiring was required.
 
-## 3. Establish crate-level documentation and glossary placeholders
+## 3. Establish crate-level documentation and glossary placeholders ✅
 - **Inputs:** Repository documentation standards (`README.md`, `docs/rust-structs-glossary.md`).
-- **Outputs:** Crate `README` describing architecture boundaries and feature gating; glossary placeholder entries for forthcoming types (`QuizEngine`, `QuizSession`, `QuizError`, `FeedbackMessage`) noting “implementation pending” so downstream writers know what to expect.
+- **Outputs:** Added `crates/quiz-core/README.md` to describe architecture boundaries and feature gating; appended placeholder glossary entries for forthcoming types (`QuizEngine`, `QuizSession`, `QuizError`, `FeedbackMessage`) in `docs/rust-structs-glossary.md`, each marked “implementation pending” so downstream writers know what to expect.
 
 ## 4. Model quiz session state structures
 - **Inputs:** Design brief architecture section, existing domain patterns for immutable state.


### PR DESCRIPTION
## Summary
- add a crate-level README that describes quiz-core architecture boundaries and feature gating
- append placeholder glossary entries for upcoming quiz engine types with implementation pending notes
- mark task 3 of the execution plan complete and reference the new documentation assets

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68efcdfb8ee0832586909f4845cf235e

## Summary by Sourcery

Add documentation scaffolding for the quiz-core crate, including a crate-level README, glossary placeholders for upcoming quiz engine types, and update the execution plan to mark documentation tasks complete.

Documentation:
- Add crates/quiz-core/README.md outlining module responsibilities and feature-gating strategy
- Append placeholder glossary entries for QuizEngine, QuizSession, QuizError, and FeedbackMessage in docs/rust-structs-glossary.md
- Update chess-quiz-engine-execution-plan.md to mark the documentation and glossary step as complete

Chores:
- Mark execution plan task 3 as complete