### PR TITLE
Expand quiz engine test coverage

### DIFF
--- a/crates/quiz-core/src/engine.rs
+++ b/crates/quiz-core/src/engine.rs
@@ -1,7 +1,346 @@
-#![allow(dead_code)]
+use crate::errors::QuizError;
+use crate::ports::{FeedbackMessage, PromptContext, QuizPort};
+use crate::source::QuizSource;
+use crate::state::{AttemptResult, QuizSession, QuizStep, QuizSummary};
 
-/// Placeholder for the quiz orchestration engine.
-///
-/// Concrete behavior will be implemented in subsequent tasks.
-#[derive(Debug, Default)]
-pub struct QuizEngine;
+/// Orchestrates quiz sessions by coordinating prompts, retries, and summaries.
+pub struct QuizEngine {
+    session: QuizSession,
+}
+
+impl QuizEngine {
+    /// Creates a new engine from an existing [`QuizSession`].
+    #[must_use]
+    pub fn new(session: QuizSession) -> Self {
+        Self { session }
+    }
+
+    /// Builds an engine from a pre-parsed [`QuizSource`].
+    #[must_use]
+    pub fn from_source(source: &QuizSource, max_retries: u8) -> Self {
+        Self::new(QuizSession::from_source(source, max_retries))
+    }
+
+    /// Parses PGN text into a quiz engine ready to run.
+    pub fn from_pgn(pgn: &str, max_retries: u8) -> Result<Self, QuizError> {
+        Ok(Self::new(QuizSession::from_pgn(pgn, max_retries)?))
+    }
+
+    /// Runs the quiz using the supplied adapter port.
+    pub fn run<P: QuizPort>(&mut self, port: &mut P) -> Result<&QuizSummary, QuizError> {
+        while !self.session.is_complete() {
+            self.process_current_step(port)?;
+        }
+
+        port.present_summary(&self.session.summary)?;
+        Ok(&self.session.summary)
+    }
+
+    fn process_current_step<P: QuizPort>(&mut self, port: &mut P) -> Result<(), QuizError> {
+        loop {
+            let step_index = self.session.current_index;
+            let total_steps = self.session.steps.len();
+            let previous_move = if step_index == 0 {
+                None
+            } else {
+                Some(self.session.steps[step_index - 1].solution_san.clone())
+            };
+
+            let (board_fen, prompt_san, remaining_retries) = {
+                let step = &self.session.steps[step_index];
+                (
+                    step.board_fen.clone(),
+                    step.prompt_san.clone(),
+                    step.attempt.remaining_retries(),
+                )
+            };
+
+            let context = PromptContext {
+                step_index,
+                total_steps,
+                board_fen,
+                prompt_san,
+                previous_move_san: previous_move,
+                remaining_retries,
+            };
+
+            let response = port.present_prompt(context)?;
+
+            let GradeOutcome {
+                feedback,
+                final_result,
+            } = {
+                let step = &mut self.session.steps[step_index];
+                Self::grade_attempt(step_index, step, response)
+            };
+
+            port.publish_feedback(feedback)?;
+
+            if let Some(result) = final_result {
+                let retries_used = self.session.steps[step_index].attempt.retries_used as usize;
+                self.session.summary.completed_steps += 1;
+                self.session.summary.retries_consumed += retries_used;
+
+                match result {
+                    AttemptResult::Correct => self.session.summary.correct_answers += 1,
+                    AttemptResult::Incorrect => self.session.summary.incorrect_answers += 1,
+                    AttemptResult::Pending => {}
+                }
+
+                self.advance();
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Advances to the next step once the current step completes.
+    fn advance(&mut self) {
+        self.session.current_index += 1;
+    }
+
+    /// Grades an attempt and returns the corresponding feedback message.
+    fn grade_attempt(step_index: usize, step: &mut QuizStep, response: String) -> GradeOutcome {
+        let trimmed = response.trim().to_string();
+        step.attempt.responses.push(trimmed.clone());
+
+        if san_matches(&trimmed, &step.solution_san) {
+            step.attempt.result = AttemptResult::Correct;
+            return GradeOutcome {
+                feedback: FeedbackMessage::success(step_index, trimmed, step.annotations.clone()),
+                final_result: Some(AttemptResult::Correct),
+            };
+        }
+
+        let remaining = step.attempt.remaining_retries();
+        if remaining > 0 {
+            step.attempt.retries_used += 1;
+            return GradeOutcome {
+                feedback: FeedbackMessage::retry(step_index, trimmed, remaining),
+                final_result: None,
+            };
+        }
+
+        step.attempt.result = AttemptResult::Incorrect;
+        GradeOutcome {
+            feedback: FeedbackMessage::failure(
+                step_index,
+                (!trimmed.is_empty()).then_some(trimmed),
+                step.solution_san.clone(),
+                step.annotations.clone(),
+            ),
+            final_result: Some(AttemptResult::Incorrect),
+        }
+    }
+
+    /// Provides read-only access to the underlying session for inspection.
+    #[must_use]
+    pub fn session(&self) -> &QuizSession {
+        &self.session
+    }
+}
+
+struct GradeOutcome {
+    feedback: FeedbackMessage,
+    final_result: Option<AttemptResult>,
+}
+
+fn san_matches(input: &str, solution: &str) -> bool {
+    let normalised_input = input.trim();
+    if normalised_input.is_empty() {
+        return false;
+    }
+
+    normalised_input.eq_ignore_ascii_case(solution.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::QuizPort;
+    use std::collections::VecDeque;
+
+    struct FakePort {
+        responses: VecDeque<String>,
+        prompts: Vec<PromptContext>,
+        feedback: Vec<FeedbackMessage>,
+        summary: Option<QuizSummary>,
+        feedback_calls: usize,
+        fail_feedback_after: Option<usize>,
+        fail_summary: bool,
+    }
+
+    impl FakePort {
+        fn with_responses(responses: Vec<&str>) -> Self {
+            Self {
+                responses: responses.into_iter().map(String::from).collect(),
+                prompts: Vec::new(),
+                feedback: Vec::new(),
+                summary: None,
+                feedback_calls: 0,
+                fail_feedback_after: None,
+                fail_summary: false,
+            }
+        }
+
+        fn failing_feedback(responses: Vec<&str>) -> Self {
+            let mut port = Self::with_responses(responses);
+            port.fail_feedback_after = Some(1);
+            port
+        }
+
+        fn failing_summary(responses: Vec<&str>) -> Self {
+            let mut port = Self::with_responses(responses);
+            port.fail_summary = true;
+            port
+        }
+    }
+
+    impl QuizPort for FakePort {
+        fn present_prompt(&mut self, context: PromptContext) -> Result<String, QuizError> {
+            self.prompts.push(context);
+            self.responses.pop_front().ok_or(QuizError::Io)
+        }
+
+        fn publish_feedback(&mut self, feedback: FeedbackMessage) -> Result<(), QuizError> {
+            self.feedback_calls += 1;
+
+            if let Some(threshold) = self.fail_feedback_after {
+                if self.feedback_calls >= threshold {
+                    return Err(QuizError::Io);
+                }
+            }
+
+            self.feedback.push(feedback);
+            Ok(())
+        }
+
+        fn present_summary(&mut self, summary: &QuizSummary) -> Result<(), QuizError> {
+            if self.fail_summary {
+                return Err(QuizError::Io);
+            }
+
+            self.summary = Some(summary.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn run_processes_correct_answers_and_publishes_summary() {
+        let mut engine = QuizEngine::from_pgn("1. e4 e5 *", 1).expect("PGN should parse");
+        let mut port = FakePort::with_responses(vec!["e4", "e5"]);
+
+        let summary = engine.run(&mut port).expect("engine should complete");
+
+        assert_eq!(summary.total_steps, 2);
+        assert_eq!(summary.correct_answers, 2);
+        assert_eq!(summary.incorrect_answers, 0);
+        assert_eq!(port.feedback.len(), 2);
+        assert!(
+            port.feedback
+                .iter()
+                .all(|msg| msg.result == AttemptResult::Correct)
+        );
+        assert!(port.summary.is_some());
+        assert_eq!(engine.session().current_index, 2);
+        assert_eq!(port.prompts.len(), 2);
+        assert!(port.prompts[0].previous_move_san.is_none());
+        assert_eq!(port.prompts[1].previous_move_san.as_deref(), Some("e4"));
+    }
+
+    #[test]
+    fn engine_allows_single_retry_and_tracks_consumed_retries() {
+        let mut engine = QuizEngine::from_pgn("1. e4 *", 1).expect("PGN should parse");
+        let mut port = FakePort::with_responses(vec!["d4", "e4"]);
+
+        let summary = engine.run(&mut port).expect("engine should complete");
+
+        assert_eq!(summary.correct_answers, 1);
+        assert_eq!(summary.retries_consumed, 1);
+        assert_eq!(port.feedback.len(), 2);
+        assert_eq!(port.feedback[0].result, AttemptResult::Pending);
+        assert_eq!(port.feedback[0].remaining_retries, 1);
+        assert_eq!(port.feedback[1].result, AttemptResult::Correct);
+        assert_eq!(port.prompts.len(), 2);
+        assert_eq!(port.prompts[0].remaining_retries, 1);
+        assert_eq!(port.prompts[1].remaining_retries, 0);
+    }
+
+    #[test]
+    fn engine_marks_incorrect_after_retry_exhaustion() {
+        let mut engine = QuizEngine::from_pgn("1. e4 *", 1).expect("PGN should parse");
+        let mut port = FakePort::with_responses(vec!["d4", "c4"]);
+
+        let summary = engine.run(&mut port).expect("engine should complete");
+
+        assert_eq!(summary.correct_answers, 0);
+        assert_eq!(summary.incorrect_answers, 1);
+        assert_eq!(summary.retries_consumed, 1);
+        assert_eq!(port.feedback.len(), 2);
+        assert_eq!(port.feedback[1].result, AttemptResult::Incorrect);
+        assert_eq!(port.feedback[1].solution_san, "e4");
+        assert_eq!(port.prompts[1].remaining_retries, 0);
+    }
+
+    #[test]
+    fn engine_bubbles_prompt_failures_without_advancing_state() {
+        let mut engine = QuizEngine::from_pgn("1. e4 *", 1).expect("PGN should parse");
+        let mut port = FakePort::with_responses(vec![]);
+
+        let error = engine
+            .run(&mut port)
+            .expect_err("prompt failure should surface");
+
+        assert_eq!(error, QuizError::Io);
+        assert_eq!(engine.session().current_index, 0);
+        assert_eq!(engine.session().summary.completed_steps, 0);
+        assert!(engine.session().steps[0].attempt.responses.is_empty());
+    }
+
+    #[test]
+    fn engine_stops_when_feedback_publication_errors() {
+        let mut engine = QuizEngine::from_pgn("1. e4 *", 1).expect("PGN should parse");
+        let mut port = FakePort::failing_feedback(vec!["e4"]);
+
+        let error = engine
+            .run(&mut port)
+            .expect_err("feedback error should propagate");
+
+        assert_eq!(error, QuizError::Io);
+        assert_eq!(engine.session().summary.completed_steps, 0);
+        assert_eq!(engine.session().current_index, 0);
+        let attempt = &engine.session().steps[0].attempt;
+        assert_eq!(attempt.responses, vec!["e4".to_string()]);
+        assert_eq!(attempt.result, AttemptResult::Correct);
+    }
+
+    #[test]
+    fn engine_preserves_summary_when_summary_delivery_fails() {
+        let mut engine = QuizEngine::from_pgn("1. e4 e5 *", 1).expect("PGN should parse");
+        let mut port = FakePort::failing_summary(vec!["e4", "e5"]);
+
+        let error = engine
+            .run(&mut port)
+            .expect_err("summary delivery failure should propagate");
+
+        assert_eq!(error, QuizError::Io);
+        assert_eq!(engine.session().summary.correct_answers, 2);
+        assert_eq!(engine.session().summary.completed_steps, 2);
+        assert_eq!(engine.session().summary.retries_consumed, 0);
+        assert!(port.summary.is_none());
+    }
+
+    #[test]
+    fn engine_records_trimmed_responses_across_retries() {
+        let mut engine = QuizEngine::from_pgn("1. e4 *", 1).expect("PGN should parse");
+        let mut port = FakePort::with_responses(vec!["   d4  ", "  E4  "]);
+
+        let summary = engine.run(&mut port).expect("engine should complete");
+
+        assert_eq!(summary.retries_consumed, 1);
+        assert_eq!(summary.correct_answers, 1);
+        let attempt = &engine.session().steps[0].attempt;
+        assert_eq!(attempt.responses, vec!["d4".to_string(), "E4".to_string()]);
+    }
+}

--- a/crates/quiz-core/src/lib.rs
+++ b/crates/quiz-core/src/lib.rs
@@ -8,6 +8,12 @@ pub mod ports;
 pub mod source;
 pub mod state;
 
+pub use engine::QuizEngine;
+pub use errors::QuizError;
+pub use ports::{FeedbackMessage, PromptContext, QuizPort};
+pub use source::QuizSource;
+pub use state::{AttemptResult, AttemptState, QuizSession, QuizStep, QuizSummary};
+
 #[cfg(feature = "cli")]
 pub mod cli;
 

--- a/docs/rust-structs-glossary.md
+++ b/docs/rust-structs-glossary.md
@@ -1059,19 +1059,25 @@ _Source:_ `crates/scheduler-core/tests/opening_scheduling.rs`
 
 ### `QuizEngine`
 
-**Overview:** Planned orchestrator responsible for executing quiz sessions against a provided
-question source and adapter port. Implementation pending while session state and port contracts are
-defined.
+**Overview:** Orchestrates quiz execution by hydrating a `QuizSession`, delegating prompts to an
+adapter `QuizPort`, and updating attempt state plus summary totals as each move is graded.
 
 **Definition:**
+```rust
+pub struct QuizEngine {
+    session: QuizSession,
+}
 ```
-// implementation pending in `crates/quiz-core/src/engine.rs`
-```
+_Source:_ `crates/quiz-core/src/engine.rs`
 
 **Usage in this repository:**
-- Will coordinate quiz execution loops, advancing through prompts, recording attempts, and producing
-  session summaries once implemented.
-- Will expose constructors such as `QuizEngine::from_pgn` that prepare state from a PGN source.
+- `QuizEngine::from_pgn` and `QuizEngine::from_source` construct runnable engines from PGN strings
+  or `QuizSource` values while configuring retry allowances for each `QuizStep`.
+- `QuizEngine::run` loops over session steps, emitting `PromptContext` values through the active
+  port, enforcing the one-retry policy via `grade_attempt`, and publishing `FeedbackMessage`
+  instances before finally calling `present_summary` with the aggregated `QuizSummary`.
+- Unit tests in `crates/quiz-core/src/engine.rs` exercise perfect runs, retry saves, and exhausted
+  attempts against a fake port to keep adapter isolation intact.
 
 ### `QuizSession`
 

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -30,9 +30,9 @@ This plan translates the chess quiz engine design brief and the surrounding repo
 - **Inputs:** Port trait sketch in the design brief, repository feature-flagging conventions.
 - **Outputs:** `ports::QuizPort` trait with prompt, feedback, and summary hooks alongside serialisable `PromptContext` and `FeedbackMessage` structs; a generically testable `TerminalPort` adapter behind the `cli` feature that wraps arbitrary `BufRead`/`Write` handles; and adapter-focused unit tests capturing stdout to verify prompt rendering, feedback wording, summary formatting, and the helper constructors so every branch of the module is exercised.
 
-## 8. Build the quiz orchestration engine
+## 8. Build the quiz orchestration engine ✅
 - **Inputs:** Session state types, port trait, retry policy (single retry) from acceptance criteria.
-- **Outputs:** `QuizEngine` implementation with constructors (`from_pgn`, `from_source`), the main execution loop (`run`), and helper methods (`advance`, `grade_attempt`). Tests simulate correct/incorrect answers, retry flows, and summary aggregation using fake ports.
+- **Outputs:** Implemented `QuizEngine` with constructors (`new`, `from_source`, `from_pgn`), the execution loop (`run`/`process_current_step`), and grading helpers that update attempts and summaries. Augmented unit tests with fake ports covering perfect runs, retry saves, exhausted retries, prompt context metadata, adapter summary publication, adapter failure propagation (prompt, feedback, summary), and attempt history capture for trimmed SAN submissions.
 
 ## 9. Harden error handling boundaries for adapters
 - **Inputs:** `QuizError` enum, adapter isolation requirement, prior error-handling tests.


### PR DESCRIPTION
## Summary
- implement the QuizEngine orchestration loop with retry-aware grading and session summary updates
- expand fake-port unit tests to cover adapter failure propagation and trimmed attempt history, and document the new expectations
- re-export quiz-core types and refresh execution plan, acceptance checklist, and glossary documentation to reflect the engine implementation

## Testing
- `cargo test -p quiz-core`
- `make test` *(fails: clippy flags an existing infallible TryFrom impl in crates/scheduler-core)*

------
https://chatgpt.com/codex/tasks/task_e_68efe97cb4e88325a2f0c19da8f4c2f6