### PR TITLE
Harden adapter error handling

### DIFF
--- a/crates/quiz-core/src/engine.rs
+++ b/crates/quiz-core/src/engine.rs
@@ -1,4 +1,4 @@
-use crate::errors::QuizError;
+use crate::errors::QuizResult;
 use crate::ports::{FeedbackMessage, PromptContext, QuizPort};
 use crate::source::QuizSource;
 use crate::state::{AttemptResult, QuizSession, QuizStep, QuizSummary};
@@ -22,12 +22,12 @@ impl QuizEngine {
     }
 
     /// Parses PGN text into a quiz engine ready to run.
-    pub fn from_pgn(pgn: &str, max_retries: u8) -> Result<Self, QuizError> {
+    pub fn from_pgn(pgn: &str, max_retries: u8) -> QuizResult<Self> {
         Ok(Self::new(QuizSession::from_pgn(pgn, max_retries)?))
     }
 
     /// Runs the quiz using the supplied adapter port.
-    pub fn run<P: QuizPort>(&mut self, port: &mut P) -> Result<&QuizSummary, QuizError> {
+    pub fn run<P: QuizPort>(&mut self, port: &mut P) -> QuizResult<&QuizSummary> {
         while !self.session.is_complete() {
             self.process_current_step(port)?;
         }
@@ -36,7 +36,7 @@ impl QuizEngine {
         Ok(&self.session.summary)
     }
 
-    fn process_current_step<P: QuizPort>(&mut self, port: &mut P) -> Result<(), QuizError> {
+    fn process_current_step<P: QuizPort>(&mut self, port: &mut P) -> QuizResult<()> {
         loop {
             let step_index = self.session.current_index;
             let total_steps = self.session.steps.len();
@@ -158,6 +158,7 @@ fn san_matches(input: &str, solution: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::errors::QuizError;
     use crate::ports::QuizPort;
     use std::collections::VecDeque;
 

--- a/crates/quiz-core/src/lib.rs
+++ b/crates/quiz-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod source;
 pub mod state;
 
 pub use engine::QuizEngine;
-pub use errors::QuizError;
+pub use errors::{AdapterResult, QuizError, QuizResult};
 pub use ports::{FeedbackMessage, PromptContext, QuizPort};
 pub use source::QuizSource;
 pub use state::{AttemptResult, AttemptState, QuizSession, QuizStep, QuizSummary};

--- a/crates/quiz-core/src/state.rs
+++ b/crates/quiz-core/src/state.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::errors::QuizError;
+use crate::errors::QuizResult;
 use crate::source::QuizSource;
 use shakmaty::fen::Fen;
 use shakmaty::{EnPassantMode, Position};
@@ -65,7 +65,7 @@ impl QuizSession {
     /// # Errors
     /// Returns a [`QuizError`] if the PGN cannot be parsed into a valid `QuizSource`.
     #[allow(clippy::result_large_err)]
-    pub fn from_pgn(pgn: &str, max_retries: u8) -> Result<Self, QuizError> {
+    pub fn from_pgn(pgn: &str, max_retries: u8) -> QuizResult<Self> {
         let source = QuizSource::from_pgn(pgn)?;
         Ok(Self::from_source(&source, max_retries))
     }

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -34,9 +34,9 @@ This plan translates the chess quiz engine design brief and the surrounding repo
 - **Inputs:** Session state types, port trait, retry policy (single retry) from acceptance criteria.
 - **Outputs:** Implemented `QuizEngine` with constructors (`new`, `from_source`, `from_pgn`), the execution loop (`run`/`process_current_step`), and grading helpers that update attempts and summaries. Augmented unit tests with fake ports covering perfect runs, retry saves, exhausted retries, prompt context metadata, adapter summary publication, adapter failure propagation (prompt, feedback, summary), and attempt history capture for trimmed SAN submissions.
 
-## 9. Harden error handling boundaries for adapters
+## 9. Harden error handling boundaries for adapters ✅
 - **Inputs:** `QuizError` enum, adapter isolation requirement, prior error-handling tests.
-- **Outputs:** Exhaustive conversions from lower-level errors (`shakmaty`, `std::io`) into `QuizError`; result aliases for adapter ergonomics; tests covering I/O failures, retry exhaustion, and summary edge cases. Update documentation to describe adapter-safe failure modes.
+- **Outputs:** Exhaustive conversions from lower-level errors (`shakmaty`, `std::io`) into `QuizError`; adapter-facing result aliases used across ports and the CLI implementation; regression tests for CLI I/O failures alongside existing retry-exhaustion and summary guard rails. Documentation updated to describe adapter-safe failure modes and the new error-conversion helpers.
 
 ## 10. Assemble integration tests for end-to-end quiz runs
 - **Inputs:** Engine implementation, terminal adapter, acceptance criteria backlog from Task 1.

--- a/documentation/chess-quiz-engine.md
+++ b/documentation/chess-quiz-engine.md
@@ -99,6 +99,13 @@ consistent position (e.g., completed steps remain counted even if summary presen
 Additional assertions cover attempt history capture, ensuring trimmed SAN responses are recorded in
 order even when learners take a retry before submitting the correct move.
 
+Task 9 extends this surface by giving adapters dedicated result aliases (`QuizResult` and
+`AdapterResult`) and `From` conversions from `std::io::Error`, `shakmaty::san::ParseSanError`, and
+`shakmaty::san::SanError`. The CLI adapter now leans on these conversions directly via the `?`
+operator, with tests that inject failing writers to prove `QuizError::Io` is surfaced without
+advancing quiz state. Parsing helpers annotate PGN failures with both the offending SAN token and the
+underlying `shakmaty` message so adapters can display actionable diagnostics.
+
 ## Implementation Roadmap
 The roadmap breaks implementation into four atomic streams. Each subsection describes candidate approaches, the trade-offs we e
 valuated, and the decision we committed to.


### PR DESCRIPTION
## Summary
- add result aliases and error conversions in `QuizError`, plus unit tests to cover the new mappings
- update the CLI adapter to rely on `?`-based propagation and add a regression test for failing writers
- route PGN parsing through the new helpers and document adapter-safe failure modes in the execution plan

## Testing
- cargo test -p quiz-core --features cli
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68eff1f10280832591facee2e0b3819b

## Summary by Sourcery

Unify and harden error handling across the quiz engine and adapters by introducing result aliases and error conversions, updating core and CLI components to use `?`-based propagation, and enriching PGN parsing with detailed diagnostics.

Enhancements:
- Introduce QuizResult and AdapterResult type aliases and export them in the library root
- Implement From conversions from std::io::Error, ParseSanError, and SanError into QuizError with helper constructors for detailed PGN error messages
- Refactor CLI adapter and QuizPort trait to use AdapterResult and `?` propagation instead of manual map_err for I/O errors
- Modify QuizSource, QuizEngine, and state methods to return QuizResult and use new error helpers for SAN parsing failures

Documentation:
- Update markdown documentation to describe adapter-safe failure modes and new error-conversion utilities

Tests:
- Add unit tests for error conversions from I/O and shakmaty SAN errors
- Add regression test ensuring CLI adapter surfaces writer I/O failures as QuizError::Io