### PR TITLE
Add end-to-end integration tests for quiz engine

### DIFF
--- a/crates/quiz-core/tests/end_to_end.rs
+++ b/crates/quiz-core/tests/end_to_end.rs
@@ -1,0 +1,131 @@
+use std::collections::VecDeque;
+
+use quiz_core::{
+    AttemptResult, FeedbackMessage, PromptContext, QuizEngine, QuizError, QuizPort, QuizSummary,
+};
+
+struct DeterministicPort {
+    responses: VecDeque<String>,
+    pub prompts: Vec<PromptContext>,
+    pub feedback: Vec<FeedbackMessage>,
+    pub summary: Option<QuizSummary>,
+}
+
+impl DeterministicPort {
+    fn new<I, S>(responses: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let responses = responses
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>();
+
+        Self {
+            responses: VecDeque::from(responses),
+            prompts: Vec::new(),
+            feedback: Vec::new(),
+            summary: None,
+        }
+    }
+}
+
+impl QuizPort for DeterministicPort {
+    fn present_prompt(&mut self, context: PromptContext) -> Result<String, QuizError> {
+        self.prompts.push(context);
+        self.responses
+            .pop_front()
+            .ok_or(QuizError::Io)
+    }
+
+    fn publish_feedback(&mut self, feedback: FeedbackMessage) -> Result<(), QuizError> {
+        self.feedback.push(feedback);
+        Ok(())
+    }
+
+    fn present_summary(&mut self, summary: &QuizSummary) -> Result<(), QuizError> {
+        self.summary = Some(summary.clone());
+        Ok(())
+    }
+}
+
+#[test]
+fn perfect_run_records_summary_and_feedback() {
+    let mut engine = QuizEngine::from_pgn("1. e4 e5 2. Nf3 Nc6 *", 1).expect("PGN should parse");
+    let mut port = DeterministicPort::new(["e4", "e5", "Nf3", "Nc6"]);
+
+    let summary = engine.run(&mut port).expect("engine should complete");
+
+    assert_eq!(summary.total_steps, 4);
+    assert_eq!(summary.completed_steps, 4);
+    assert_eq!(summary.correct_answers, 4);
+    assert_eq!(summary.incorrect_answers, 0);
+    assert_eq!(summary.retries_consumed, 0);
+    assert_eq!(port.feedback.len(), 4);
+    assert!(port
+        .feedback
+        .iter()
+        .all(|message| message.result == AttemptResult::Correct));
+    assert_eq!(port.summary.as_ref(), Some(summary));
+    assert_eq!(port.prompts.len(), 4);
+    assert!(port.prompts.iter().all(|prompt| prompt.remaining_retries == 1));
+}
+
+#[test]
+fn retry_then_success_flow_consumes_single_retry() {
+    let mut engine = QuizEngine::from_pgn("1. e4 e5 *", 1).expect("PGN should parse");
+    let mut port = DeterministicPort::new(["d4", "e4", "e5"]);
+
+    let summary = engine.run(&mut port).expect("engine should complete");
+
+    assert_eq!(summary.correct_answers, 2);
+    assert_eq!(summary.incorrect_answers, 0);
+    assert_eq!(summary.retries_consumed, 1);
+    assert_eq!(summary.completed_steps, 2);
+
+    assert_eq!(port.prompts.len(), 3);
+    assert_eq!(port.prompts[0].step_index, 0);
+    assert_eq!(port.prompts[0].remaining_retries, 1);
+    assert_eq!(port.prompts[1].step_index, 0);
+    assert_eq!(port.prompts[1].remaining_retries, 0);
+    assert_eq!(port.prompts[2].step_index, 1);
+    assert_eq!(port.prompts[2].remaining_retries, 1);
+
+    assert_eq!(port.feedback.len(), 3);
+    assert_eq!(port.feedback[0].result, AttemptResult::Pending);
+    assert_eq!(port.feedback[0].remaining_retries, 1);
+    assert_eq!(port.feedback[1].result, AttemptResult::Correct);
+    assert_eq!(port.feedback[2].result, AttemptResult::Correct);
+    assert_eq!(port.summary.as_ref(), Some(summary));
+}
+
+#[test]
+fn failure_after_retry_is_captured_in_summary_and_feedback() {
+    let mut engine = QuizEngine::from_pgn("1. e4 *", 1).expect("PGN should parse");
+    let mut port = DeterministicPort::new(["d4", "Nc3"]);
+
+    let summary = engine.run(&mut port).expect("engine should complete");
+
+    assert_eq!(summary.correct_answers, 0);
+    assert_eq!(summary.incorrect_answers, 1);
+    assert_eq!(summary.retries_consumed, 1);
+    assert_eq!(summary.completed_steps, 1);
+
+    assert_eq!(port.feedback.len(), 2);
+    assert_eq!(port.feedback[0].result, AttemptResult::Pending);
+    assert_eq!(port.feedback[1].result, AttemptResult::Incorrect);
+    assert_eq!(port.feedback[1].solution_san, "e4");
+    assert_eq!(
+        port.feedback[1].learner_response.as_deref(),
+        Some("Nc3")
+    );
+    assert_eq!(port.summary.as_ref(), Some(summary));
+}
+
+#[test]
+fn pgn_variations_are_rejected_during_engine_construction() {
+    let result = QuizEngine::from_pgn("1. e4 e5 (1... c5) 2. Nf3 Nc6 *", 1);
+
+    assert!(matches!(result, Err(QuizError::VariationsUnsupported)));
+}

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -38,9 +38,9 @@ This plan translates the chess quiz engine design brief and the surrounding repo
 - **Inputs:** `QuizError` enum, adapter isolation requirement, prior error-handling tests.
 - **Outputs:** Exhaustive conversions from lower-level errors (`shakmaty`, `std::io`) into `QuizError`; adapter-facing result aliases used across ports and the CLI implementation; regression tests for CLI I/O failures alongside existing retry-exhaustion and summary guard rails. Documentation updated to describe adapter-safe failure modes and the new error-conversion helpers.
 
-## 10. Assemble integration tests for end-to-end quiz runs
+## 10. Assemble integration tests for end-to-end quiz runs ✅
 - **Inputs:** Engine implementation, terminal adapter, acceptance criteria backlog from Task 1.
-- **Outputs:** Integration tests under `crates/quiz-core/tests/` that orchestrate full quiz sessions with deterministic ports. Scenarios cover perfect runs, retries leading to success, failures after retries, and PGN parsing rejection. Tests start as red cases before the relevant code is implemented.
+- **Outputs:** Integration tests under `crates/quiz-core/tests/end_to_end.rs` orchestrate full quiz sessions with deterministic ports. Scenarios cover perfect runs, retries leading to success, failures after retries, and PGN parsing rejection, verifying adapter prompts, feedback, and summary delivery in one flow.
 
 ## 11. Update documentation and knowledge artifacts
 - **Inputs:** Implemented API surface, glossary placeholders, documentation obligations described in the brief.

--- a/documentation/chess-quiz-engine.md
+++ b/documentation/chess-quiz-engine.md
@@ -106,6 +106,15 @@ operator, with tests that inject failing writers to prove `QuizError::Io` is sur
 advancing quiz state. Parsing helpers annotate PGN failures with both the offending SAN token and the
 underlying `shakmaty` message so adapters can display actionable diagnostics.
 
+### End-to-End Integration Tests
+
+Task 10 adds integration coverage in `crates/quiz-core/tests/end_to_end.rs`, pairing the engine with a
+deterministic fake port to drive complete quiz sessions. These tests exercise the full loop mandated
+by the acceptance criteria: a perfect run with zero retries, a single-retry recovery, retry
+exhaustion leading to a recorded miss, and PGN parsing rejection. The port fixture records prompts,
+feedback, and the delivered summary, giving confidence that adapter interactions and summary totals
+stay coherent across the entire session.
+
 ## Implementation Roadmap
 The roadmap breaks implementation into four atomic streams. Each subsection describes candidate approaches, the trade-offs we e
 valuated, and the decision we committed to.


### PR DESCRIPTION
## Summary
- add a deterministic fake port integration harness to exercise end-to-end quiz engine flows
- document task 10 completion and describe the new integration coverage in the execution plan and design brief

## Testing
- cargo test -p quiz-core

------
https://chatgpt.com/codex/tasks/task_e_68f0085b8cb48325a41769896141c345

## Summary by Sourcery

Add comprehensive end-to-end integration tests for the quiz engine with a deterministic port fixture and update documentation and execution plan to reflect the new coverage.

New Features:
- Add end-to-end integration tests using a deterministic fake port to validate full quiz engine flows

Documentation:
- Document end-to-end test coverage in chess-quiz-engine.md and mark task 10 as completed in the execution plan

Tests:
- Introduce DeterministicPort and four end-to-end tests in crates/quiz-core/tests/end_to_end.rs covering perfect runs, retry recovery, retry exhaustion, and PGN parsing rejection