### PR TITLE
Add empty PGN regression test for quiz engine

### DIFF
--- a/crates/quiz-core/tests/end_to_end.rs
+++ b/crates/quiz-core/tests/end_to_end.rs
@@ -129,3 +129,10 @@ fn pgn_variations_are_rejected_during_engine_construction() {
 
     assert!(matches!(result, Err(QuizError::VariationsUnsupported)));
 }
+
+#[test]
+fn empty_pgn_is_rejected_during_engine_construction() {
+    let result = QuizEngine::from_pgn("", 1);
+
+    assert!(matches!(result, Err(QuizError::NoMoves)));
+}


### PR DESCRIPTION
## Summary
- add an integration test ensuring `QuizEngine::from_pgn` rejects empty PGN input

## Testing
- cargo test -p quiz-core

------
https://chatgpt.com/codex/tasks/task_e_68f016aec40083259d2f28ec907fe8da

## Summary by Sourcery

Tests:
- Add test ensuring that passing an empty PGN string to QuizEngine::from_pgn yields a QuizError::NoMoves.