### PR TITLE
Document quiz engine current state and glossary

### DIFF
--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -42,9 +42,9 @@ This plan translates the chess quiz engine design brief and the surrounding repo
 - **Inputs:** Engine implementation, terminal adapter, acceptance criteria backlog from Task 1.
 - **Outputs:** Integration tests under `crates/quiz-core/tests/end_to_end.rs` orchestrate full quiz sessions with deterministic ports. Scenarios cover perfect runs, retries leading to success, failures after retries, and PGN parsing rejection, verifying adapter prompts, feedback, and summary delivery in one flow.
 
-## 11. Update documentation and knowledge artifacts
+## 11. Update documentation and knowledge artifacts ✅
 - **Inputs:** Implemented API surface, glossary placeholders, documentation obligations described in the brief.
-- **Outputs:** Revised `documentation/chess-quiz-engine.md` capturing key decisions and implementation notes; updated glossary entries with full definitions and code snippets; crate-level README diagrams or tables illustrating adapter usage; changelog entry if the repository maintains one.
+- **Outputs:** Revised `documentation/chess-quiz-engine.md` capturing key decisions, current-state analysis, and implementation notes; updated glossary entries with full definitions and code snippets; crate-level README tables illustrating adapter usage; changelog entry if the repository maintains one.
 
 ## 12. Plan follow-on integration work and backlog items
 - **Inputs:** Engine deliverables, dependencies on PGN importer, scheduler, and UI adapters noted in repository docs.


### PR DESCRIPTION
## Summary
- document the quiz engine's current status, open work, and follow-up suggestions in the design brief
- mark task 11 complete in the execution plan and align the crate README with the implemented engine and adapters
- expand the rust struct glossary with the quiz-core data structures and usage notes

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f38b1e60d88325a0947fb938a1d7fe

## Summary by Sourcery

Update and expand quiz engine documentation to reflect the current implementation state

Documentation:
- Add comprehensive Rust struct glossary entries for quiz-core data structures with definitions and usage notes
- Revise crates/quiz-core README to document session hydration, execution engine, adapter isolation, module map, and feature flags
- Update the chess-quiz-engine design brief with current state, pending work items, identified issues, and adjustment suggestions
- Mark task 11 complete in the execution plan and align outputs descriptions with implemented documentation