### PR TITLE
Document current quiz engine state

### DIFF
--- a/crates/quiz-core/README.md
+++ b/crates/quiz-core/README.md
@@ -48,6 +48,14 @@ flowchart LR
 Enable features with `cargo build --features "cli"` to compile the corresponding adapter and its
 binary entry point.
 
+### Adapter quick reference
+
+| Adapter | Feature flag | Entry point | Typical usage |
+| ------- | ------------- | ----------- | -------------- |
+| TerminalPort | `cli` | `cargo run --features "cli" --bin cli` | Manual testing in a terminal using buffered stdin/stdout handles. |
+| API (stub) | `api` | `cargo run --features "api" --bin api` | Placeholder for future HTTP adapter; currently prints `todo!`. |
+| WASM (stub) | `wasm` | `cargo run --features "wasm" --bin wasm` | Placeholder for browser embedding experiments. |
+
 ## Related documentation
 
 - [Chess Quiz Engine design brief](../../documentation/chess-quiz-engine.md)

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -44,7 +44,7 @@ This plan translates the chess quiz engine design brief and the surrounding repo
 
 ## 11. Update documentation and knowledge artifacts ✅
 - **Inputs:** Implemented API surface, glossary placeholders, documentation obligations described in the brief.
-- **Outputs:** Revised `documentation/chess-quiz-engine.md` capturing key decisions, current-state analysis, and implementation notes; updated glossary entries with full definitions and code snippets; crate-level README tables illustrating adapter usage; changelog entry if the repository maintains one.
+- **Outputs:** Revised `documentation/chess-quiz-engine.md` capturing key decisions, current-state analysis, and implementation notes (see the "Current State" dashboard and refreshed architecture notes); updated glossary entries with full definitions and usage guidance; crate-level README tables illustrating adapter usage via the "Adapter quick reference"; changelog entry if the repository maintains one.
 
 ## 12. Plan follow-on integration work and backlog items
 - **Inputs:** Engine deliverables, dependencies on PGN importer, scheduler, and UI adapters noted in repository docs.


### PR DESCRIPTION
## Summary
- refresh the chess quiz engine design brief with a new current-state dashboard and clearer references to implementation details
- expand the struct glossary usage notes to highlight how the engine loop and adapters consume each data structure
- add an adapter quick-reference table to the crate README and cross-link task 11 outputs in the execution plan

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f398d267408325bea1874a4108557b

## Summary by Sourcery

Refresh and expand documentation to reflect the quiz engine’s current design and usage, including updated design brief, glossary entries, adapter references, and execution plan cross-links.

Documentation:
- Refresh design brief with a current-state dashboard and detailed implementation annotations
- Expand glossary usage notes to highlight engine loop steps, adapter interactions, and test references
- Add an adapter quick-reference table to the crate README with feature flags, entry points, and usage scenarios
- Update execution plan task outputs to reference the new documentation artifacts