### PR TITLE
fix: align retry feedback counts

### DIFF
--- a/crates/quiz-core/src/engine.rs
+++ b/crates/quiz-core/src/engine.rs
@@ -119,11 +119,12 @@ impl QuizEngine {
             };
         }
 
-        let remaining = step.attempt.remaining_retries();
-        if remaining > 0 {
+        let remaining_before = step.attempt.remaining_retries();
+        if remaining_before > 0 {
             step.attempt.retries_used += 1;
+            let remaining_after = step.attempt.remaining_retries();
             return GradeOutcome {
-                feedback: FeedbackMessage::retry(step_index, trimmed, remaining),
+                feedback: FeedbackMessage::retry(step_index, trimmed, remaining_after),
                 final_result: None,
             };
         }
@@ -267,7 +268,7 @@ mod tests {
         assert_eq!(summary.retries_consumed, 1);
         assert_eq!(port.feedback.len(), 2);
         assert_eq!(port.feedback[0].result, AttemptResult::Pending);
-        assert_eq!(port.feedback[0].remaining_retries, 1);
+        assert_eq!(port.feedback[0].remaining_retries, 0);
         assert_eq!(port.feedback[1].result, AttemptResult::Correct);
         assert_eq!(port.prompts.len(), 2);
         assert_eq!(port.prompts[0].remaining_retries, 1);

--- a/crates/quiz-core/src/ports.rs
+++ b/crates/quiz-core/src/ports.rs
@@ -271,7 +271,7 @@ mod tests {
         let writer = Vec::new();
         let mut port = TerminalPort::with_io(input, writer);
 
-        let message = FeedbackMessage::retry(0, "Qh5", 1);
+        let message = FeedbackMessage::retry(0, "Qh5", 0);
 
         port.publish_feedback(message)
             .expect("feedback output should succeed");
@@ -279,7 +279,7 @@ mod tests {
         let (_, writer) = port.into_inner();
         let output = String::from_utf8(writer).expect("utf8");
         assert!(output.contains("Incorrect, try again."));
-        assert!(output.contains("Retries remaining: 1"));
+        assert!(output.contains("Retries remaining: 0"));
         assert!(output.contains("Your answer: Qh5"));
     }
 

--- a/crates/quiz-core/tests/end_to_end.rs
+++ b/crates/quiz-core/tests/end_to_end.rs
@@ -108,7 +108,7 @@ fn retry_then_success_flow_consumes_single_retry() {
 
     assert_eq!(port.feedback.len(), 3);
     assert_eq!(port.feedback[0].result, AttemptResult::Pending);
-    assert_eq!(port.feedback[0].remaining_retries, 1);
+    assert_eq!(port.feedback[0].remaining_retries, 0);
     assert_eq!(port.feedback[1].result, AttemptResult::Correct);
     assert_eq!(port.feedback[2].result, AttemptResult::Correct);
     assert_eq!(port.summary.as_ref(), Some(summary));

--- a/docs/rust-structs-glossary.md
+++ b/docs/rust-structs-glossary.md
@@ -75,7 +75,7 @@ _Source:_ `crates/quiz-core/src/state.rs`
 
 **Usage in this repository:**
 - `AttemptState::new` initialises retry budgets for each step during session hydration.
-- `AttemptState::remaining_retries` informs prompt contexts and feedback messaging about available retries and is used in retry bookkeeping tests.
+- `AttemptState::remaining_retries` informs prompt contexts and, after the retry bookkeeping fix, always reflects the allowance remaining once the most recent attempt has been accounted for.
 
 ### `AttemptResult`
 
@@ -172,7 +172,7 @@ _Source:_ `crates/quiz-core/src/ports.rs`
 
 **Usage in this repository:**
 - Created by `FeedbackMessage::success`, `retry`, and `failure` helpers invoked from `QuizEngine::grade_attempt`.
-- Rendered in the terminal adapter to communicate success, retry prompts, and final reveals to learners; tests assert each constructor's semantics.
+- Rendered in the terminal adapter to communicate success, retry prompts, and final reveals to learners; after the retry messaging fix the `remaining_retries` field now reports the post-attempt allowance so adapters display accurate guidance.
 
 ### `QuizError`
 

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -9,19 +9,14 @@ before they are considered complete.
 
 ## Stabilise the core feedback loop
 
-### [T1] Align retry messaging with consumed allowances
-- **Objective:** Ensure `FeedbackMessage::retry` and terminal output report the
-  number of retries remaining *after* the current miss so learners receive
-  accurate guidance.
-- **Primary inputs:** `crates/quiz-core/src/engine.rs`
-  (`grade_attempt`), `crates/quiz-core/src/cli.rs` (`TerminalPort::publish_feedback`).
-- **Deliverables:** Update retry bookkeeping so the attempt state increments
-  before generating retry feedback. Adjust `FeedbackMessage` constructors if
-  required and extend unit tests to assert the new count. Confirm the terminal
-  adapter prints the corrected allowance.
-- **Verification:** Red tests in `engine` module covering exhausted retries and
-  terminal adapter tests confirming the displayed counts. No dependencies on
-  other tasks.
+### [T1] Align retry messaging with consumed allowances — ✅ Completed (`fix(engine): align retry feedback with consumed allowances`)
+- **Outcome:** `grade_attempt` now increments `retries_used` before building
+  retry feedback so `FeedbackMessage::retry` reflects the true allowance after a
+  miss. Terminal feedback mirrors the updated count, preventing learners from
+  seeing stale retry totals.
+- **Verification:** Extended engine, integration, and terminal adapter tests
+  assert the consumed retry budget and printed allowance all read as zero after
+  the first failed attempt.
 
 ### [T2] Accept equivalent SAN notations during grading
 - **Objective:** Prevent false negatives when learners include optional suffixes

--- a/documentation/chess-quiz-engine.md
+++ b/documentation/chess-quiz-engine.md
@@ -9,18 +9,17 @@ single source of truth for how the quiz workflow operates.
 
 ### 1. Current state of our most basic quiz engine
 - `QuizEngine::run` drives each step through `process_current_step`, constructing a `PromptContext`, capturing SAN responses, grading them with `grade_attempt`, and publishing a terminal summary via the injected port.【F:crates/quiz-core/src/engine.rs†L32-L147】
+- `grade_attempt` increments `retries_used` before producing retry feedback so `FeedbackMessage::retry` and the terminal adapter both report the remaining allowance after a miss.【F:crates/quiz-core/src/engine.rs†L110-L141】【F:crates/quiz-core/src/cli.rs†L78-L119】
 - Session hydration comes from `QuizSource::from_pgn`, producing `QuizStep` entries whose FEN boards and SAN prompts remain aligned with the legal move sequence while initialising retry allowances inside `QuizSession::from_source`.【F:crates/quiz-core/src/source.rs†L19-L86】【F:crates/quiz-core/src/state.rs†L16-L121】
 - Adapter boundaries stay encapsulated by serialisable `PromptContext` and `FeedbackMessage` types, and the terminal adapter exercises every branch of the prompt/feedback/summary loop using buffered handles under the `cli` feature flag.【F:crates/quiz-core/src/ports.rs†L7-L115】【F:crates/quiz-core/src/cli.rs†L41-L134】
 - Error handling is centralised in `QuizError` with ready-made conversions so adapters operate purely on `QuizResult` aliases instead of wiring their own plumbing.【F:crates/quiz-core/src/errors.rs†L1-L88】
 
 ### 2. Work effort still required for an mvp
 The execution plan in `documentation/chess-quiz-engine-execution-plan.md` breaks
-the remaining work into atomic tasks [T1]–[T8]. The highlights below summarise
-the gaps each task closes:
+the remaining work into atomic tasks [T1]–[T8]. Task [T1] has now landed, and the
+highlights below summarise its impact alongside the outstanding work items:
 
-- **[T1] Retry messaging alignment.** `grade_attempt` emits retry feedback
-  before incrementing the attempt counter, causing `FeedbackMessage::retry` and
-  the terminal adapter to overstate remaining allowances.【F:crates/quiz-core/src/engine.rs†L76-L120】【F:crates/quiz-core/src/cli.rs†L72-L118】
+- **[T1] Retry messaging alignment.** ✅ Completed via `fix(engine): align retry feedback with consumed allowances`; retry feedback now reports the post-miss allowance and terminal messaging mirrors the updated count.【F:crates/quiz-core/src/engine.rs†L110-L141】【F:crates/quiz-core/tests/end_to_end.rs†L90-L115】
 - **[T2] SAN equivalence.** `san_matches` treats `Nf3+` and `Nf3` as different
   moves, penalising learners for optional suffixes or glyphs.【F:crates/quiz-core/src/engine.rs†L130-L167】
 - **[T3] Stable metadata.** `QuizStep` and `PromptContext` expose no identifiers
@@ -40,9 +39,7 @@ the gaps each task closes:
 The gaps identified above map directly to plan tasks so contributors can close
 them methodically:
 
-- **Retry allowances ([T1]).** `grade_attempt` captures `remaining_retries`
-  before incrementing `retries_used`, so adapters overstate how many chances
-  learners retain.【F:crates/quiz-core/src/engine.rs†L83-L133】【F:crates/quiz-core/src/cli.rs†L74-L113】
+- **Retry allowances ([T1]).** Addressed by incrementing `retries_used` ahead of building retry feedback so adapters surface the true remaining count.【F:crates/quiz-core/src/engine.rs†L110-L141】
 - **SAN suffix handling ([T2]).** `san_matches` ignores case but still requires
   exact SAN tokens, rejecting equivalent moves when learners include suffixes or
   glyphs.【F:crates/quiz-core/src/engine.rs†L155-L167】
@@ -51,9 +48,7 @@ them methodically:
   records.【F:crates/quiz-core/src/state.rs†L53-L103】【F:crates/quiz-core/src/ports.rs†L25-L61】
 
 ### 4. Any suggestions for adjustments based on those issues?
-- **[T1] Retry messaging.** Increment retries before constructing
-  `FeedbackMessage::retry` so adapters display accurate allowances and the
-  summary tallies remain consistent.【F:crates/quiz-core/src/engine.rs†L83-L133】
+- **[T1] Retry messaging.** ✅ Delivered: retry feedback now reflects the consumed allowance, keeping adapter copy and summary tallies aligned.【F:crates/quiz-core/src/engine.rs†L110-L141】【F:crates/quiz-core/src/ports.rs†L244-L305】
 - **[T2] SAN normalisation.** Extend `san_matches` (or its callers) to strip
   optional suffix markers or parse via `shakmaty::San` so equivalent notation is
   accepted.【F:crates/quiz-core/src/engine.rs†L155-L167】


### PR DESCRIPTION
## Summary
- increment retry bookkeeping before emitting `FeedbackMessage::retry` so learners see remaining allowances after a miss
- update terminal adapter and integration tests to assert the corrected retry counts
- mark T1 as complete in the execution plan, refresh the design brief, and note the glossary semantics change

## Testing
- cargo test -p quiz-core

------
https://chatgpt.com/codex/tasks/task_e_68f39f92f7d08325aacc2ced6e37c7ac

## Summary by Sourcery

Fix retry feedback off-by-one by incrementing retries before generating feedback, and update related documentation and tests to reflect the correct remaining retries count

Bug Fixes:
- Increment retry bookkeeping before emitting retry feedback so FeedbackMessage::retry and terminal output report the correct remaining retries

Documentation:
- Mark task T1 as completed in the execution plan and update design documentation and glossary to reflect the new retry semantics

Tests:
- Adjust engine, integration, terminal adapter, and end-to-end tests to expect zero remaining retries after the first failed attempt