### PR TITLE
feat: add durable metadata flow for quiz steps

### DIFF
--- a/crates/quiz-core/src/cli.rs
+++ b/crates/quiz-core/src/cli.rs
@@ -56,6 +56,26 @@ where
             writeln!(self.writer, "Previous move: {previous}")?;
         }
 
+        if let Some(step_id) = context.metadata.step_id.as_deref() {
+            writeln!(self.writer, "Step ID: {step_id}")?;
+        }
+
+        if !context.metadata.theme_tags.is_empty() {
+            writeln!(
+                self.writer,
+                "Themes: {}",
+                context.metadata.theme_tags.join(", ")
+            )?;
+        }
+
+        if !context.metadata.card_ids.is_empty() {
+            writeln!(
+                self.writer,
+                "Card references: {}",
+                context.metadata.card_ids.join(", ")
+            )?;
+        }
+
         writeln!(self.writer, "Your move (SAN): {}", context.prompt_san)?;
 
         if context.remaining_retries > 0 {

--- a/crates/quiz-core/src/state.rs
+++ b/crates/quiz-core/src/state.rs
@@ -114,6 +114,8 @@ pub struct QuizStep {
     pub attempt: AttemptState,
     /// Optional annotations that accompany the step once graded.
     pub annotations: Vec<String>,
+    /// Optional metadata used to correlate steps with external schedulers.
+    pub metadata: StepMetadata,
 }
 
 impl QuizStep {
@@ -134,8 +136,20 @@ impl QuizStep {
             solution_san: solution_san.into(),
             attempt: AttemptState::new(max_retries),
             annotations: Vec::new(),
+            metadata: StepMetadata::default(),
         }
     }
+}
+
+/// Stable metadata describing how a quiz step maps back to the learner's repertoire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct StepMetadata {
+    /// Durable identifier for the step when persisted outside the engine.
+    pub step_id: Option<String>,
+    /// Semantic tags that describe the tactical or strategic theme of the prompt.
+    pub theme_tags: Vec<String>,
+    /// External card identifiers that reference spaced-repetition records.
+    pub card_ids: Vec<String>,
 }
 
 /// Represents the current attempt status for a single quiz step.
@@ -273,6 +287,15 @@ mod tests {
         assert_eq!(step.attempt.retries_allowed, 2);
         assert_eq!(step.attempt.retries_used, 0);
         assert_eq!(step.attempt.result, AttemptResult::Pending);
+    }
+
+    #[test]
+    fn quiz_step_initialises_metadata_as_empty() {
+        let step = sample_step(1);
+
+        assert_eq!(step.metadata.step_id, None);
+        assert!(step.metadata.theme_tags.is_empty());
+        assert!(step.metadata.card_ids.is_empty());
     }
 
     #[test]

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -36,19 +36,17 @@ before they are considered complete.
 
 ## Expand session context and fidelity
 
-### [T3] Introduce durable step identifiers and metadata
-- **Objective:** Provide stable identifiers, themes, and card references so
-  schedulers and adapters can correlate quiz progress with stored repertoire
-  entries.
-- **Primary inputs:** `crates/quiz-core/src/state.rs` (`QuizStep`, `PromptContext`),
-  `crates/quiz-core/src/ports.rs`.
-- **Deliverables:** Extend state structs with optional identifier/metadata
-  fields, hydrate them during session creation, and ensure serialisation traits
-  remain valid. Update adapter prompt rendering and fake ports/tests to assert
-  the new fields are preserved end-to-end.
-- **Verification:** Unit tests in `state` and `engine` modules plus integration
-  tests verifying the metadata flows through the fake port fixtures. No
-  dependency on other tasks.
+### [T3] Introduce durable step identifiers and metadata ✅
+- **Status:** Completed via `feat(quiz-core): add durable step metadata surfaces`.
+- **Outcome:** `QuizStep` exposes a `StepMetadata` payload (step IDs, theme tags,
+  spaced-repetition card IDs) that now propagates into `PromptContext` and
+  `FeedbackMessage`. The terminal adapter renders the metadata and tests assert
+  fake ports capture it.
+- **Primary inputs:** `crates/quiz-core/src/state.rs` (`QuizStep`, `StepMetadata`),
+  `crates/quiz-core/src/ports.rs`, `crates/quiz-core/src/engine.rs`,
+  `crates/quiz-core/src/cli.rs`.
+- **Verification:** Unit tests in `state`, `engine`, and `ports` modules confirm
+  metadata hydration, propagation, and adapter output.
 
 ### [T4] Preserve PGN annotations and surface them in feedback
 - **Objective:** Carry commentary and move-level annotations from the source PGN


### PR DESCRIPTION
## Summary
- add `StepMetadata` to quiz steps and thread it through prompt contexts and feedback messages
- expose the new metadata on the terminal adapter and extend engine/port tests to cover the end-to-end flow
- document the completion of task T3, including updated design notes and glossary entries

## Testing
- cargo test -p quiz-core

------
https://chatgpt.com/codex/tasks/task_e_68f39fa1e3ec8325beecd461f555bea3

## Summary by Sourcery

Add a permanent metadata flow for quiz steps by introducing StepMetadata and ensuring it travels from QuizStep through the engine to ports, with terminal rendering and documentation updates.

New Features:
- Introduce StepMetadata to carry durable step IDs, theme tags, and card IDs across the quiz flow

Enhancements:
- Propagate metadata through QuizEngine into PromptContext and FeedbackMessage
- Extend TerminalPort to render metadata when available

Documentation:
- Update glossary, execution plan, and main documentation to describe StepMetadata and its usage

Tests:
- Add unit tests to verify metadata initialization, propagation, and rendering in fake and terminal adapters