### PR TITLE
feat: add durable quiz step metadata surfaces

### DIFF
--- a/crates/quiz-core/src/cli.rs
+++ b/crates/quiz-core/src/cli.rs
@@ -52,6 +52,22 @@ where
         )?;
         writeln!(self.writer, "Board FEN: {}", context.board_fen)?;
 
+        if let Some(step_id) = context.metadata.step_id.as_deref() {
+            writeln!(self.writer, "Step ID: {step_id}")?;
+        }
+
+        if let Some(card_ref) = context.metadata.card_ref.as_deref() {
+            writeln!(self.writer, "Card ref: {card_ref}")?;
+        }
+
+        if !context.metadata.themes.is_empty() {
+            writeln!(
+                self.writer,
+                "Themes: {}",
+                context.metadata.themes.join(", ")
+            )?;
+        }
+
         if let Some(previous) = context.previous_move_san.as_deref() {
             writeln!(self.writer, "Previous move: {previous}")?;
         }
@@ -79,6 +95,12 @@ where
         match feedback.result {
             AttemptResult::Correct => {
                 writeln!(self.writer, "Correct!")?;
+                if let Some(step_id) = feedback.metadata.step_id.as_deref() {
+                    writeln!(self.writer, "Step ID: {step_id}")?;
+                }
+                if let Some(card_ref) = feedback.metadata.card_ref.as_deref() {
+                    writeln!(self.writer, "Card ref: {card_ref}")?;
+                }
                 for note in &feedback.annotations {
                     writeln!(self.writer, "Note: {note}")?;
                 }
@@ -93,6 +115,9 @@ where
 
                 if let Some(response) = &feedback.learner_response {
                     writeln!(self.writer, "Your answer: {response}")?;
+                }
+                if let Some(step_id) = feedback.metadata.step_id.as_deref() {
+                    writeln!(self.writer, "Step ID: {step_id}")?;
                 }
             }
             AttemptResult::Incorrect => {
@@ -111,6 +136,13 @@ where
                     for note in &feedback.annotations {
                         writeln!(self.writer, "- {note}")?;
                     }
+                }
+
+                if let Some(step_id) = feedback.metadata.step_id.as_deref() {
+                    writeln!(self.writer, "Step ID: {step_id}")?;
+                }
+                if let Some(card_ref) = feedback.metadata.card_ref.as_deref() {
+                    writeln!(self.writer, "Card ref: {card_ref}")?;
                 }
             }
         }

--- a/crates/quiz-core/src/source.rs
+++ b/crates/quiz-core/src/source.rs
@@ -5,6 +5,7 @@ use shakmaty::san::{ParseSanError, San, SanError};
 use shakmaty::{Chess, Position};
 
 use crate::errors::{QuizError, QuizResult};
+use crate::state::StepMetadata;
 
 /// Represents a parsed PGN quiz source comprised of a single game's main line.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,6 +14,8 @@ pub struct QuizSource {
     pub initial_position: Chess,
     /// Ordered SAN moves that make up the quiz prompts.
     pub san_moves: Vec<San>,
+    /// Optional metadata captured alongside each SAN move.
+    pub step_metadata: Vec<StepMetadata>,
 }
 
 impl QuizSource {
@@ -87,7 +90,15 @@ impl QuizSource {
         Ok(Self {
             initial_position,
             san_moves,
+            step_metadata: Vec::new(),
         })
+    }
+
+    /// Attaches metadata to each SAN move, returning the enriched source.
+    #[must_use]
+    pub fn with_step_metadata(mut self, metadata: Vec<StepMetadata>) -> Self {
+        self.step_metadata = metadata;
+        self
     }
 }
 

--- a/docs/rust-structs-glossary.md
+++ b/docs/rust-structs-glossary.md
@@ -40,7 +40,7 @@ _Source:_ `crates/quiz-core/src/state.rs`
 
 ### `QuizStep`
 
-**Overview:** Represents a single move challenge, pairing the board snapshot, SAN prompt, canonical solution, attempt tracking, and optional annotations.
+**Overview:** Represents a single move challenge, pairing the board snapshot, SAN prompt, canonical solution, attempt tracking, optional annotations, and durable metadata for repertoire correlation.
 
 **Definition:**
 ```rust
@@ -50,13 +50,32 @@ pub struct QuizStep {
     pub solution_san: String,
     pub attempt: AttemptState,
     pub annotations: Vec<String>,
+    pub metadata: StepMetadata,
 }
 ```
 _Source:_ `crates/quiz-core/src/state.rs`
 
 **Usage in this repository:**
-- Hydrated by `hydrate_steps` when building sessions from PGN input, ensuring every SAN move is paired with a legal board position.
-- Mutated by `QuizEngine::grade_attempt` to push learner responses and record outcomes, and consumed by adapters when rendering prompts and reveals.
+- Hydrated by `hydrate_steps` when building sessions from PGN input, ensuring every SAN move is paired with a legal board position and receives canonical `StepMetadata` when none is provided by the source.
+- Mutated by `QuizEngine::grade_attempt` to push learner responses, record outcomes, and surface metadata to adapters when rendering prompts and reveals.
+
+### `StepMetadata`
+
+**Overview:** Encapsulates durable identifiers, repertoire references, and theme tags attached to a quiz step so adapters and schedulers can map attempts back to stored content.
+
+**Definition:**
+```rust
+pub struct StepMetadata {
+    pub step_id: Option<String>,
+    pub card_ref: Option<String>,
+    pub themes: Vec<String>,
+}
+```
+_Source:_ `crates/quiz-core/src/state.rs`
+
+**Usage in this repository:**
+- Generated during hydration to provide canonical `quiz-step-{index}` identifiers when no external metadata is supplied.
+- Propagated through `PromptContext` and `FeedbackMessage` so adapters can persist identifiers, card references, and theme tags in their own transports.
 
 ### `AttemptState`
 
@@ -117,20 +136,21 @@ _Source:_ `crates/quiz-core/src/state.rs`
 
 ### `QuizSource`
 
-**Overview:** Parsed representation of a single PGN game's main line used to hydrate quiz sessions.
+**Overview:** Parsed representation of a single PGN game's main line used to hydrate quiz sessions, including optional metadata seeds for each move.
 
 **Definition:**
 ```rust
 pub struct QuizSource {
     pub initial_position: Chess,
     pub san_moves: Vec<San>,
+    pub step_metadata: Vec<StepMetadata>,
 }
 ```
 _Source:_ `crates/quiz-core/src/source.rs`
 
 **Usage in this repository:**
-- `QuizSource::from_pgn` normalises SAN tokens, rejects comments or variations, and prepares the move list for session hydration.
-- `QuizEngine::from_source` consumes a `QuizSource` to construct a ready-to-run session with consistent FEN snapshots, and unit tests assert the error variants for malformed PGN.
+- `QuizSource::from_pgn` normalises SAN tokens, rejects comments or variations, and prepares the move list for session hydration, initialising an empty metadata vector by default.
+- `QuizEngine::from_source` consumes a `QuizSource` to construct a ready-to-run session with consistent FEN snapshots and metadata propagation, and unit tests assert the error variants for malformed PGN.
 
 ### `PromptContext`
 
@@ -145,13 +165,14 @@ pub struct PromptContext {
     pub prompt_san: String,
     pub previous_move_san: Option<String>,
     pub remaining_retries: u8,
+    pub metadata: StepMetadata,
 }
 ```
 _Source:_ `crates/quiz-core/src/ports.rs`
 
 **Usage in this repository:**
-- Constructed by `QuizEngine::process_current_step` before every prompt to supply adapters with rendering context.
-- Terminal and fake adapters display the board snapshot and retry counts derived from this struct, and the CLI module exposes helpers that rely on its `display_index` method.
+- Constructed by `QuizEngine::process_current_step` before every prompt to supply adapters with rendering context and metadata for correlation.
+- Terminal and fake adapters display the board snapshot, retry counts, and metadata derived from this struct, and the CLI module exposes helpers that rely on its `display_index` method.
 
 ### `FeedbackMessage`
 
@@ -166,13 +187,14 @@ pub struct FeedbackMessage {
     pub solution_san: String,
     pub annotations: Vec<String>,
     pub remaining_retries: u8,
+    pub metadata: StepMetadata,
 }
 ```
 _Source:_ `crates/quiz-core/src/ports.rs`
 
 **Usage in this repository:**
 - Created by `FeedbackMessage::success`, `retry`, and `failure` helpers invoked from `QuizEngine::grade_attempt`.
-- Rendered in the terminal adapter to communicate success, retry prompts, and final reveals to learners; tests assert each constructor's semantics.
+- Rendered in the terminal adapter to communicate success, retry prompts, and final reveals to learners, including metadata required by downstream schedulers; tests assert each constructor's semantics.
 
 ### `QuizError`
 

--- a/documentation/chess-quiz-engine-execution-plan.md
+++ b/documentation/chess-quiz-engine-execution-plan.md
@@ -49,6 +49,13 @@ before they are considered complete.
 - **Verification:** Unit tests in `state` and `engine` modules plus integration
   tests verifying the metadata flows through the fake port fixtures. No
   dependency on other tasks.
+- **Status:** ✅ Completed – `feat: add durable quiz step metadata surfaces`
+  - `QuizStep` now carries a `StepMetadata` payload with canonical step IDs,
+    optional repertoire references, and deduplicated theme tags hydrated from
+    `QuizSource` or generated from the step index.
+  - `PromptContext` and `FeedbackMessage` mirror the metadata to adapters, and
+    the terminal port renders the new fields; unit and integration tests assert
+    metadata fidelity across hydration, grading, and CLI presentation.
 
 ### [T4] Preserve PGN annotations and surface them in feedback
 - **Objective:** Carry commentary and move-level annotations from the source PGN


### PR DESCRIPTION
## Summary
- add `StepMetadata` to quiz state hydration, defaulting canonical identifiers and allowing PGN sources to inject metadata
- propagate metadata through `PromptContext`/`FeedbackMessage`, rendering identifiers, card references, and themes in the CLI adapter with expanded tests
- refresh the execution plan, design brief, and struct glossary to mark T3 complete and document the new metadata flow

## Testing
- `cargo test -p quiz-core`


------
https://chatgpt.com/codex/tasks/task_e_68f39fa1e3ec8325beecd461f555bea3

## Summary by Sourcery

Support durable quiz step metadata by introducing StepMetadata, hydrating it from sources or generating canonical IDs, and surfacing identifiers, card references, and themes through the engine, ports, and CLI adapters.

New Features:
- Introduce StepMetadata struct to encapsulate durable step IDs, card references, and themes for each quiz step
- Extend QuizSource to accept injected step metadata and generate canonical identifiers when none is provided

Enhancements:
- Propagate metadata through QuizStep hydration, QuizEngine prompt and feedback contexts, and CLI rendering
- Normalize theme tags and support custom metadata assignment via with_step_metadata on QuizStep and QuizSource

Documentation:
- Update Rust structs glossary, execution plan, and engine documentation to include StepMetadata and metadata flow details

Tests:
- Add unit and integration tests to verify metadata hydration, normalization, and propagation through prompts and feedback